### PR TITLE
feat: extend validatePIXId to accept mobile phones and EMV QR payloads

### DIFF
--- a/src/country/currencies/brl.ts
+++ b/src/country/currencies/brl.ts
@@ -52,16 +52,23 @@ function validateCNPJ(cnpj: string): boolean {
 
 /**
  * Validates PIX ID format.
- * PIX can be: CPF (11 digits), CNPJ (14 digits), email, phone, or random key (UUID).
+ * PIX can be: CPF (11 digits), CNPJ (14 digits), email, phone (10–11 digits or E.164),
+ * random key (UUID), or a PIX "copia e cola" EMV QR payload (starts with 000201).
  */
 export function validatePIXId(pixId: string): boolean {
 	if (!pixId || pixId.trim().length === 0) return false;
 
 	const trimmedPixId = pixId.trim();
 
-	if (/^\d{11}$/.test(trimmedPixId)) return validateCPF(trimmedPixId);
+	// PIX "copia e cola" — EMV QR code payload
+	if (/^000201/.test(trimmedPixId)) return true;
+
+	// 11 digits: valid CPF or Brazilian mobile phone key (DDD 11–99 + digit 9 + 8 digits)
+	if (/^\d{11}$/.test(trimmedPixId))
+		return validateCPF(trimmedPixId) || /^[1-9][1-9]9\d{8}$/.test(trimmedPixId);
 	if (/^\d{14}$/.test(trimmedPixId)) return validateCNPJ(trimmedPixId);
 	if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedPixId)) return true;
+	// Phone key: 10–11 digits (with or without country code prefix)
 	if (/^\d{10,11}$/.test(trimmedPixId)) return true;
 	if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(trimmedPixId))
 		return true;

--- a/test/country/validators.test.ts
+++ b/test/country/validators.test.ts
@@ -69,9 +69,13 @@ describe("validatePIXId (BRL)", () => {
 	it.each([
 		["valid CPF", "52998224725"],
 		["valid email", "user@example.com"],
-		// 11-digit strings are treated as CPF — use 10-digit for phone key
 		["10-digit phone (landline)", "1198765432"],
+		["11-digit mobile phone", "91996339865"],
 		["valid UUID", "123e4567-e89b-12d3-a456-426614174000"],
+		[
+			"PIX copia e cola (EMV QR payload)",
+			"00020126540012br.gov.bcb.pix0132pix_marketplace@mercadolibre.com5204000053039865406647.025802BR5911@33368855466009SaoPaulo62250521mpqrinter15399624083763016A57",
+		],
 	])("accepts %s", (_label, input) => {
 		expect(validatePIXId(input)).toBe(true);
 	});
@@ -79,8 +83,9 @@ describe("validatePIXId (BRL)", () => {
 	it.each([
 		["empty string", ""],
 		["whitespace only", "   "],
+		// 11-digit invalid CPF whose 3rd digit ≠ 9 (also not a mobile phone key)
 		["CPF all same digits", "11111111111"],
-		["CPF wrong check digit", "52998224724"],
+		["CPF wrong check digit", "12345678901"],
 		["CNPJ all same digits", "11111111111111"],
 		["invalid format", "not-a-pix-key"],
 		["partial UUID", "123e4567-e89b-12d3-a456"],
@@ -94,8 +99,8 @@ describe("validatePIXId (BRL)", () => {
 			expect(validatePIXId("11144477735")).toBe(true);
 		});
 
-		it("rejects CPF with flipped last digit", () => {
-			expect(validatePIXId("52998224726")).toBe(false);
+		it("rejects CPF with flipped last digit (3rd digit not 9, cannot be phone)", () => {
+			expect(validatePIXId("11144477736")).toBe(false);
 		});
 	});
 

--- a/test/country/validators.test.ts
+++ b/test/country/validators.test.ts
@@ -74,7 +74,7 @@ describe("validatePIXId (BRL)", () => {
 		["valid UUID", "123e4567-e89b-12d3-a456-426614174000"],
 		[
 			"PIX copia e cola (EMV QR payload)",
-			"00020126540012br.gov.bcb.pix0132pix_marketplace@mercadolibre.com5204000053039865406647.025802BR5911@33368855466009SaoPaulo62250521mpqrinter15399624083763016A57",
+			"00020127890012br.gov.bcb.pix0132pix_randomuser@paymenthub.net5204000053039865406123.458802BR5911@87492011666009RioDeJaneiro62250521mpqrinter84736291520463016B93",
 		],
 	])("accepts %s", (_label, input) => {
 		expect(validatePIXId(input)).toBe(true);


### PR DESCRIPTION
- Accept PIX "copia e cola" strings (EMV QR payloads starting with 000201)
- Accept 11-digit Brazilian mobile phone keys (DDD + 9 + 8 digits) in addition to valid CPFs
- Update tests to cover new cases and replace CPF-vs-phone ambiguous fixtures