### PR TITLE
feat: add Binance to SocialPlatform

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@p2pdotme/sdk",
@@ -27,8 +26,8 @@
         "vitest": "4.1.2",
       },
       "peerDependencies": {
-        "@reclaimprotocol/js-sdk": "^4",
-        "@zkpassport/sdk": "^0.12.4",
+        "@reclaimprotocol/js-sdk": "^5",
+        "@zkpassport/sdk": ">=0.12.4 <0.15.0",
         "react": "18 || ^19",
       },
       "optionalPeers": [

--- a/example/zk-verify-instagram.ts
+++ b/example/zk-verify-instagram.ts
@@ -65,9 +65,9 @@ async function main(): Promise<void> {
 	kv("Platform", PLATFORM);
 	kv("Wallet", walletAddress);
 
-	// ── 2. Start the Reclaim flow ─────────────────────────────────────
-	step(2, "Start Reclaim session and wait for proof");
-	const proofResult = await createReclaimFlow({
+	// ── 2. Initialize the Reclaim session (on page load) ──────────────
+	step(2, "Initialize Reclaim session");
+	const sessionResult = await createReclaimFlow({
 		appId: RECLAIM_APP_ID,
 		appSecret: RECLAIM_APP_SECRET,
 		providerIds: DEFAULT_RECLAIM_PROVIDER_IDS,
@@ -94,13 +94,22 @@ async function main(): Promise<void> {
 		},
 	});
 
+	if (sessionResult.isErr()) {
+		console.error(`   ✖ Reclaim init failed (${sessionResult.error.code}): ${sessionResult.error.message}`);
+		process.exit(1);
+	}
+
+	// ── 3. Start verification (on user action) — triggers the flow + polls ──
+	step(3, "Start verification and wait for proof");
+	const proofResult = await sessionResult.value.start();
+
 	if (proofResult.isErr()) {
 		console.error(`   ✖ Reclaim flow failed (${proofResult.error.code}): ${proofResult.error.message}`);
 		process.exit(1);
 	}
 	const proof = proofResult.value;
 
-	step(3, "Proof summary");
+	step(4, "Proof summary");
 	kv("_socialName", proof._socialName);
 	kv("sessionId", proof.sessionId);
 	kv("proofs", proof.proofs.length);
@@ -111,7 +120,7 @@ async function main(): Promise<void> {
 	}
 
 	// ── 3. Prepare the on-chain calldata ──────────────────────────────
-	step(4, "Prepare socialVerify calldata");
+	step(5, "Prepare socialVerify calldata");
 	const zkkyc = createZkkyc({ reputationManagerAddress: REPUTATION_MANAGER_ADDRESS });
 	const prepared = zkkyc.prepareSocialVerify({
 		_socialName: proof._socialName,
@@ -132,7 +141,7 @@ async function main(): Promise<void> {
 	}
 
 	// ── 4. Submit ─────────────────────────────────────────────────────
-	step(5, "Submit socialVerify on-chain");
+	step(6, "Submit socialVerify on-chain");
 	const account = privateKeyToAccount(PRIVATE_KEY);
 	const transport = http(RPC_URL);
 	const publicClient = createPublicClient({ chain: CHAIN, transport });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p2pdotme/sdk",
-  "version": "1.2.1",
+  "version": "1.2.1-kyc.2",
   "description": "P2P.me SDK",
   "license": "MIT",
   "type": "module",
@@ -62,16 +62,36 @@
   },
   "typesVersions": {
     "*": {
-      ".": ["./dist/index.d.ts"],
-      "orders": ["./dist/orders.d.ts"],
-      "react": ["./dist/react.d.ts"],
-      "qr-parsers": ["./dist/qr-parsers.d.ts"],
-      "fraud-engine": ["./dist/fraud-engine.d.ts"],
-      "profile": ["./dist/profile.d.ts"],
-      "prices": ["./dist/prices.d.ts"],
-      "stake": ["./dist/stake.d.ts"],
-      "country": ["./dist/country.d.ts"],
-      "zkkyc": ["./dist/zkkyc.d.ts"]
+      ".": [
+        "./dist/index.d.ts"
+      ],
+      "orders": [
+        "./dist/orders.d.ts"
+      ],
+      "react": [
+        "./dist/react.d.ts"
+      ],
+      "qr-parsers": [
+        "./dist/qr-parsers.d.ts"
+      ],
+      "fraud-engine": [
+        "./dist/fraud-engine.d.ts"
+      ],
+      "profile": [
+        "./dist/profile.d.ts"
+      ],
+      "prices": [
+        "./dist/prices.d.ts"
+      ],
+      "stake": [
+        "./dist/stake.d.ts"
+      ],
+      "country": [
+        "./dist/country.d.ts"
+      ],
+      "zkkyc": [
+        "./dist/zkkyc.d.ts"
+      ]
     }
   },
   "files": [
@@ -123,7 +143,7 @@
   },
   "peerDependencies": {
     "react": "18 || ^19",
-    "@reclaimprotocol/js-sdk": "^4",
+    "@reclaimprotocol/js-sdk": "^5",
     "@zkpassport/sdk": ">=0.12.4 <0.15.0"
   },
   "peerDependenciesMeta": {

--- a/src/contracts/abis/reputation-manager.ts
+++ b/src/contracts/abis/reputation-manager.ts
@@ -197,4 +197,30 @@ export const reputationManagerAbi = [
 		stateMutability: "nonpayable",
 		type: "function",
 	},
+	{
+		inputs: [
+			{ internalType: "bytes32", name: "nullifier", type: "bytes32" },
+			{ internalType: "uint256", name: "limit", type: "uint256" },
+			{ internalType: "uint256", name: "expiry", type: "uint256" },
+			{ internalType: "bytes", name: "signature", type: "bytes" },
+		],
+		name: "submitKycAttestation",
+		outputs: [],
+		stateMutability: "nonpayable",
+		type: "function",
+	},
+	{
+		inputs: [],
+		name: "kycRp",
+		outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+		stateMutability: "view",
+		type: "function",
+	},
+	{
+		inputs: [{ internalType: "address", name: "", type: "address" }],
+		name: "kycVerified",
+		outputs: [{ internalType: "bool", name: "", type: "bool" }],
+		stateMutability: "view",
+		type: "function",
+	},
 ] as const;

--- a/src/contracts/reputation-manager/index.ts
+++ b/src/contracts/reputation-manager/index.ts
@@ -1,5 +1,6 @@
 export {
 	prepareSocialVerify,
 	prepareSubmitAnonAadharProof,
+	prepareSubmitKycAttestation,
 	prepareZkPassportRegister,
 } from "./writes";

--- a/src/contracts/reputation-manager/writes.ts
+++ b/src/contracts/reputation-manager/writes.ts
@@ -4,11 +4,13 @@ import { validate } from "../../validation";
 import { ZkkycError } from "../../zkkyc/errors";
 import type {
 	AnonAadharProofParams,
+	SimpleKycSubmitParams,
 	SocialVerifyParams,
 	ZkPassportRegisterParams,
 } from "../../zkkyc/validation";
 import {
 	ZodAnonAadharProofParamsSchema,
+	ZodSimpleKycSubmitParamsSchema,
 	ZodSocialVerifyParamsSchema,
 	ZodZkPassportRegisterParamsSchema,
 } from "../../zkkyc/validation";
@@ -85,6 +87,40 @@ export function prepareSubmitAnonAadharProof(
 			}),
 			(error) =>
 				new ZkkycError("Failed to encode submitAnonAadharProof", {
+					code: "ENCODE_ERROR",
+					cause: error,
+				}),
+		)(),
+	);
+}
+
+/** Prepares a simple-kyc EIP-712 attestation submission (awards KYC rp). */
+export function prepareSubmitKycAttestation(
+	reputationManagerAddress: Address,
+	params: SimpleKycSubmitParams,
+): Result<{ to: Address; data: `0x${string}` }, ZkkycError> {
+	return validate(
+		ZodSimpleKycSubmitParamsSchema,
+		params,
+		(message, cause, data) =>
+			new ZkkycError(message, { code: "VALIDATION_ERROR", cause, context: { params: data } }),
+	).andThen((validated) =>
+		Result.fromThrowable(
+			() => ({
+				to: reputationManagerAddress,
+				data: encodeFunctionData({
+					abi: ABIS.EXTERNAL.REPUTATION_MANAGER,
+					functionName: "submitKycAttestation",
+					args: [
+						validated.nullifier as `0x${string}`,
+						validated.limit,
+						validated.expiry,
+						validated.signature as `0x${string}`,
+					],
+				}),
+			}),
+			(error) =>
+				new ZkkycError("Failed to encode submitKycAttestation", {
 					code: "ENCODE_ERROR",
 					cause: error,
 				}),

--- a/src/zkkyc/README.md
+++ b/src/zkkyc/README.md
@@ -29,9 +29,9 @@ import { createWalletClient, http } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { baseSepolia } from "viem/chains";
 
-// 1. Run the Reclaim UX flow — user scans the deep link on their phone and
-//    completes the verification; the promise resolves with the proof.
-const proofResult = await createReclaimFlow({
+// 1. Initialize the Reclaim session (on page load). `init()` runs here, so the
+//    request URL is ready immediately for display as a QR / deep link.
+const sessionResult = await createReclaimFlow({
   appId: RECLAIM_APP_ID,
   appSecret: RECLAIM_APP_SECRET,
   providerIds: DEFAULT_RECLAIM_PROVIDER_IDS,
@@ -39,9 +39,15 @@ const proofResult = await createReclaimFlow({
   walletAddress: account.address,
   onStatus: (s) => console.log(s),
 });
+if (sessionResult.isErr()) throw sessionResult.error;
+const session = sessionResult.value;
+
+// 2. Start verification (on user action — e.g. button click). This triggers the
+//    in-app flow and polls until the proof arrives. `session.abort()` cancels it.
+const proofResult = await session.start();
 if (proofResult.isErr()) throw proofResult.error;
 
-// 2. Prepare the on-chain calldata.
+// 3. Prepare the on-chain calldata.
 const zkkyc = createZkkyc({ reputationManagerAddress: REP_MANAGER_ADDRESS });
 const prepared = zkkyc.prepareSocialVerify({
   _socialName: proofResult.value._socialName,
@@ -79,9 +85,9 @@ Returns:
 
 All three are pure encoders; no network, no wallet.
 
-### `createReclaimFlow(params)` → `ResultAsync<ReclaimProofResult, ZkkycError>`
+### `createReclaimFlow(params)` → `ResultAsync<ReclaimSession, ZkkycError>`
 
-Runs the full Reclaim flow: initializes a session, surfaces the request URL via `onStatus` so the consumer can display a QR / deep-link, polls the Reclaim API until a proof arrives, transforms the proof for on-chain use, and returns it.
+Initializes a Reclaim session and returns it. `init()` runs eagerly, so call this on page load — the request URL is surfaced via the `session_created` `onStatus` event (and on `session.requestUrl`) for immediate QR / deep-link display. Calling `session.start()` (on user action, e.g. a button click) triggers the in-app flow, polls the Reclaim API until a proof arrives, transforms it for on-chain use, and resolves with `ReclaimProofResult`. `session.abort()` cancels in-flight polling.
 
 Single-object `ReclaimFlowParams` (app-level config + per-call options merged):
 

--- a/src/zkkyc/client.ts
+++ b/src/zkkyc/client.ts
@@ -3,12 +3,14 @@ import type { Address } from "viem";
 import {
 	prepareSocialVerify,
 	prepareSubmitAnonAadharProof,
+	prepareSubmitKycAttestation,
 	prepareZkPassportRegister,
 } from "../contracts/reputation-manager/writes";
 import type { ZkkycError } from "./errors";
 import type { ZkkycConfig } from "./types";
 import type {
 	AnonAadharProofParams,
+	SimpleKycSubmitParams,
 	SocialVerifyParams,
 	ZkPassportRegisterParams,
 } from "./validation";
@@ -22,6 +24,9 @@ export interface Zkkyc {
 	): Result<{ to: Address; data: `0x${string}` }, ZkkycError>;
 	prepareZkPassportRegister(
 		params: ZkPassportRegisterParams,
+	): Result<{ to: Address; data: `0x${string}` }, ZkkycError>;
+	prepareSubmitKycAttestation(
+		params: SimpleKycSubmitParams,
 	): Result<{ to: Address; data: `0x${string}` }, ZkkycError>;
 }
 
@@ -37,5 +42,7 @@ export function createZkkyc(config: ZkkycConfig): Zkkyc {
 			prepareSubmitAnonAadharProof(reputationManagerAddress, params),
 		prepareZkPassportRegister: (params) =>
 			prepareZkPassportRegister(reputationManagerAddress, params),
+		prepareSubmitKycAttestation: (params) =>
+			prepareSubmitKycAttestation(reputationManagerAddress, params),
 	};
 }

--- a/src/zkkyc/errors.ts
+++ b/src/zkkyc/errors.ts
@@ -13,6 +13,8 @@ export type ZkkycErrorCode =
 	| "ZK_PASSPORT_REJECTED"
 	| "ZK_PASSPORT_VERIFICATION_FAILED"
 	| "ZK_PASSPORT_ABORTED"
+	| "SIMPLE_KYC_SESSION_FAILED"
+	| "SIMPLE_KYC_REDEEM_FAILED"
 	| "PEER_DEPENDENCY_MISSING";
 
 export class ZkkycError extends SdkError<ZkkycErrorCode> {

--- a/src/zkkyc/index.ts
+++ b/src/zkkyc/index.ts
@@ -5,6 +5,7 @@ export { ZkkycError } from "./errors";
 export type { ZkkycConfig } from "./types";
 export type {
 	AnonAadharProofParams,
+	SimpleKycSubmitParams,
 	SocialVerifyParams,
 	ZkPassportRegisterParams,
 } from "./validation";
@@ -14,13 +15,20 @@ export type {
 export {
 	DEFAULT_RECLAIM_PROVIDER_IDS,
 	RECLAIM_APP_LINKS,
+	SIMPLE_KYC_DEFAULT_TENANT,
 	ZK_PASSPORT_APP_LINKS,
 } from "./orchestrators/constants";
 export { createReclaimFlow } from "./orchestrators/reclaim";
+export { createSimpleKycFlow, resumeSimpleKycFlow } from "./orchestrators/simple-kyc";
 export type {
 	ReclaimFlowParams,
 	ReclaimProofResult,
+	ReclaimSession,
 	ReclaimStatus,
+	SimpleKycAttestation,
+	SimpleKycFlowParams,
+	SimpleKycSession,
+	SimpleKycStatus,
 	SocialPlatform,
 	ZkPassportFlowParams,
 	ZkPassportProofResult,

--- a/src/zkkyc/orchestrators/constants.ts
+++ b/src/zkkyc/orchestrators/constants.ts
@@ -7,6 +7,7 @@ export const DEFAULT_RECLAIM_PROVIDER_IDS: Record<SocialPlatform, string> = {
 	x: "aad95818-f726-4a34-be97-8d1f47631b03",
 	instagram: "7e5b59a9-56c5-490c-a169-82a443f9b507",
 	facebook: "2701510b-c835-4820-84f0-d9e74569656b",
+	binance: "7e40c007-f432-4d47-ac00-3e0762f8a7a0",
 };
 
 /** ZK Passport app store links. */

--- a/src/zkkyc/orchestrators/constants.ts
+++ b/src/zkkyc/orchestrators/constants.ts
@@ -20,3 +20,6 @@ export const ZK_PASSPORT_APP_LINKS = {
 export const RECLAIM_APP_LINKS = {
 	ANDROID: "https://play.google.com/store/apps/details?id=org.reclaimprotocol.app",
 } as const;
+
+/** Default tenant slug for the P2P reputation contract on the simple-kyc service. */
+export const SIMPLE_KYC_DEFAULT_TENANT = "p2p-reputation";

--- a/src/zkkyc/orchestrators/reclaim.ts
+++ b/src/zkkyc/orchestrators/reclaim.ts
@@ -1,14 +1,18 @@
 import { ResultAsync } from "neverthrow";
 import { ZkkycError } from "../errors";
-import type { ReclaimFlowParams, ReclaimProofResult } from "./types";
+import type { ReclaimFlowParams, ReclaimProofResult, ReclaimSession } from "./types";
 import { SOCIAL_PLATFORM_NAMES } from "./types";
 
 const RECLAIM_SESSION_API = "https://api.reclaimprotocol.org/api/sdk/session";
 
-/** Runs the Reclaim social verification flow and returns proof data for on-chain submission. */
+/**
+ * Initializes a Reclaim social verification flow and returns a session. `init()`
+ * runs eagerly here, so call this on page load; the returned session's `start()`
+ * triggers the in-app flow and polls for the proof, so call that on user action.
+ */
 export function createReclaimFlow(
 	params: ReclaimFlowParams,
-): ResultAsync<ReclaimProofResult, ZkkycError> {
+): ResultAsync<ReclaimSession, ZkkycError> {
 	return ResultAsync.fromPromise(
 		(async () => {
 			// biome-ignore lint/suspicious/noExplicitAny: optional peer dependency
@@ -37,13 +41,21 @@ export function createReclaimFlow(
 			const socialName = SOCIAL_PLATFORM_NAMES[platform];
 			const providerId = providerIds[platform];
 
+			// biome-ignore lint/suspicious/noExplicitAny: optional peer dependency
+			let reclaimProofRequest: any = null;
 			let sessionId: string;
+			let requestUrl = "";
 
 			if (existingSessionId) {
 				sessionId = existingSessionId;
 			} else {
-				const reclaimProofRequest = await ReclaimProofRequest.init(appId, appSecret, providerId, {
-					launchOptions: { canUseDeferredDeepLinksFlow: true },
+				reclaimProofRequest = await ReclaimProofRequest.init(appId, appSecret, providerId, {
+					launchOptions: {
+						canUseDeferredDeepLinksFlow: true,
+						verificationMode: "app",
+					},
+					useAppClip: true,
+					log: true,
 				});
 
 				const statusUrl = reclaimProofRequest.getStatusUrl();
@@ -61,67 +73,89 @@ export function createReclaimFlow(
 					contextDescription ?? `Social verification for ${socialName}`,
 				);
 
-				const requestUrl = await reclaimProofRequest.getRequestUrl();
+				requestUrl = await reclaimProofRequest.getRequestUrl();
 
 				onStatus?.({ type: "session_created", sessionId, requestUrl });
-
-				if (typeof window !== "undefined") {
-					reclaimProofRequest.triggerReclaimFlow();
-				}
 			}
 
-			onStatus?.({ type: "polling_started", sessionId });
+			let aborted = false;
 
-			while (true) {
-				if (signal?.aborted) {
-					throw new ZkkycError("Reclaim polling aborted", {
-						code: "RECLAIM_POLLING_ABORTED",
-					});
+			const pollForProof = async (): Promise<ReclaimProofResult> => {
+				if (reclaimProofRequest && typeof window !== "undefined") {
+					reclaimProofRequest.triggerReclaimFlow({ verificationMode: "app" });
 				}
 
-				const response = await fetch(`${RECLAIM_SESSION_API}/${sessionId}`);
-				const data = await response.json();
+				onStatus?.({ type: "polling_started", sessionId });
 
-				if (data?.session?.proofs?.length > 0) {
-					const proofs = data.session.proofs;
-					onStatus?.({ type: "proof_received" });
-
-					if (platform === "github" && proofs.length > 0) {
-						const first = proofs[0] as { publicData?: Record<string, unknown> };
-						if (first?.publicData && Object.keys(first.publicData).length === 0) {
-							throw new ZkkycError("GitHub verification eligibility criteria not met", {
-								code: "RECLAIM_PROOF_INVALID",
-							});
-						}
+				while (true) {
+					if (aborted || signal?.aborted) {
+						throw new ZkkycError("Reclaim polling aborted", {
+							code: "RECLAIM_POLLING_ABORTED",
+						});
 					}
 
-					const transformedProofs = proofs.map((proof: unknown) => transformForOnchain(proof));
+					const response = await fetch(`${RECLAIM_SESSION_API}/${sessionId}`);
+					const data = await response.json();
 
-					onStatus?.({ type: "proof_transformed" });
+					if (data?.session?.proofs?.length > 0) {
+						const proofs = data.session.proofs;
+						onStatus?.({ type: "proof_received" });
 
-					return {
-						_socialName: socialName,
-						proofs: transformedProofs,
-						sessionId,
-					} as ReclaimProofResult;
+						if (platform === "github" && proofs.length > 0) {
+							const first = proofs[0] as { publicData?: Record<string, unknown> };
+							if (first?.publicData && Object.keys(first.publicData).length === 0) {
+								throw new ZkkycError("GitHub verification eligibility criteria not met", {
+									code: "RECLAIM_PROOF_INVALID",
+								});
+							}
+						}
+
+						const transformedProofs = proofs.map((proof: unknown) => transformForOnchain(proof));
+
+						onStatus?.({ type: "proof_transformed" });
+
+						return {
+							_socialName: socialName,
+							proofs: transformedProofs,
+							sessionId,
+						} as ReclaimProofResult;
+					}
+
+					if (data?.message?.includes("Session not found")) {
+						throw new ZkkycError("Reclaim session not found", {
+							code: "RECLAIM_SESSION_NOT_FOUND",
+							context: { sessionId },
+						});
+					}
+
+					if (data?.session?.statusV2 === "PROOF_GENERATION_FAILED") {
+						throw new ZkkycError("Reclaim proof generation failed", {
+							code: "RECLAIM_PROOF_GENERATION_FAILED",
+							context: { sessionId },
+						});
+					}
+
+					await new Promise((resolve) => setTimeout(resolve, pollingIntervalMs));
 				}
+			};
 
-				if (data?.message?.includes("Session not found")) {
-					throw new ZkkycError("Reclaim session not found", {
-						code: "RECLAIM_SESSION_NOT_FOUND",
-						context: { sessionId },
-					});
-				}
+			const session: ReclaimSession = {
+				sessionId,
+				requestUrl,
+				start: () =>
+					ResultAsync.fromPromise(pollForProof(), (error) => {
+						if (error instanceof ZkkycError) return error;
+						return new ZkkycError("Reclaim verification flow failed", {
+							code: "RECLAIM_INIT_FAILED",
+							cause: error,
+						});
+					}),
+				abort: () => {
+					aborted = true;
+				},
+			};
 
-				if (data?.session?.statusV2 === "PROOF_GENERATION_FAILED") {
-					throw new ZkkycError("Reclaim proof generation failed", {
-						code: "RECLAIM_PROOF_GENERATION_FAILED",
-						context: { sessionId },
-					});
-				}
-
-				await new Promise((resolve) => setTimeout(resolve, pollingIntervalMs));
-			}
+			return session;
 		})(),
 		(error) => {
 			if (error instanceof ZkkycError) return error;

--- a/src/zkkyc/orchestrators/simple-kyc.ts
+++ b/src/zkkyc/orchestrators/simple-kyc.ts
@@ -1,0 +1,108 @@
+import { ResultAsync } from "neverthrow";
+import { ZkkycError } from "../errors";
+import type { SimpleKycAttestation, SimpleKycFlowParams, SimpleKycSession } from "./types";
+
+/**
+ * Starts the hosted simple-kyc wizard flow. Creates a browser-initiable widget
+ * session (no API key in the browser — `baseUrl` points at the kyc-proxy, which
+ * injects the key and whose tenant allowlist validates the redirect_uri), then
+ * returns the wizard URL to navigate to.
+ *
+ * The wizard runs passport → liveness → face match/dedup and, on approval,
+ * redirects back to `redirectUrl` with `?code=<code>&state=<state>`. Call
+ * `resumeSimpleKycFlow({ baseUrl, code })` on return to fetch the attestation.
+ */
+export function createSimpleKycFlow(
+	params: SimpleKycFlowParams,
+): ResultAsync<SimpleKycSession, ZkkycError> {
+	const { baseUrl, walletAddress, tenant, redirectUrl, country, state, onStatus } = params;
+	return ResultAsync.fromPromise(
+		(async () => {
+			const res = await fetch(`${baseUrl}/v1/widget/public-sessions`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					wallet_pubkey: walletAddress,
+					redirect_uri: redirectUrl,
+					tenant,
+					country,
+					state,
+				}),
+			});
+			if (!res.ok) {
+				const body = await res.text();
+				throw new ZkkycError(`simple-kyc session creation failed: ${res.status} ${body}`, {
+					code: "SIMPLE_KYC_SESSION_FAILED",
+					context: { status: res.status },
+				});
+			}
+			const data = (await res.json()) as { widget_url: string };
+			const widgetUrl = data.widget_url;
+			onStatus?.({ type: "session_created", widgetUrl });
+			return {
+				widgetUrl,
+				redirect: () => {
+					if (typeof window !== "undefined") {
+						onStatus?.({ type: "redirecting", widgetUrl });
+						window.location.href = widgetUrl;
+					}
+				},
+			} satisfies SimpleKycSession;
+		})(),
+		(error) => {
+			if (error instanceof ZkkycError) return error;
+			return new ZkkycError("simple-kyc flow failed to start", {
+				code: "SIMPLE_KYC_SESSION_FAILED",
+				cause: error,
+			});
+		},
+	);
+}
+
+/**
+ * Redeems the one-time `kyc_code` from the wizard's redirect for the EIP-712
+ * attestation. The result feeds straight into `zkkyc.prepareSubmitKycAttestation`.
+ * The endpoint returns only the (non-PII, self-verifying) attestation.
+ */
+export function resumeSimpleKycFlow(args: {
+	baseUrl: string;
+	code: string;
+}): ResultAsync<SimpleKycAttestation, ZkkycError> {
+	return ResultAsync.fromPromise(
+		(async () => {
+			const res = await fetch(`${args.baseUrl}/v1/widget/attestation`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ code: args.code }),
+			});
+			if (!res.ok) {
+				const body = await res.text();
+				throw new ZkkycError(`simple-kyc attestation redemption failed: ${res.status} ${body}`, {
+					code: "SIMPLE_KYC_REDEEM_FAILED",
+					context: { status: res.status },
+				});
+			}
+			const d = (await res.json()) as {
+				nullifier: string;
+				limit: string | number;
+				expiry: string | number;
+				signature: string;
+				identity_hash?: string;
+			};
+			return {
+				nullifier: d.nullifier as `0x${string}`,
+				limit: BigInt(d.limit),
+				expiry: BigInt(d.expiry),
+				signature: d.signature as `0x${string}`,
+				identityHash: d.identity_hash,
+			} satisfies SimpleKycAttestation;
+		})(),
+		(error) => {
+			if (error instanceof ZkkycError) return error;
+			return new ZkkycError("simple-kyc attestation redemption failed", {
+				code: "SIMPLE_KYC_REDEEM_FAILED",
+				cause: error,
+			});
+		},
+	);
+}

--- a/src/zkkyc/orchestrators/types.ts
+++ b/src/zkkyc/orchestrators/types.ts
@@ -5,7 +5,7 @@ import type { SolidityVerifierParameters } from "../validation";
 
 // ── Social Platform ──────────────────────────────────────────────────────────
 
-export type SocialPlatform = "linkedin" | "github" | "x" | "instagram" | "facebook";
+export type SocialPlatform = "linkedin" | "github" | "x" | "instagram" | "facebook" | "binance";
 
 /** Maps SocialPlatform to the capitalized name the contract expects for _socialName. */
 export const SOCIAL_PLATFORM_NAMES: Record<SocialPlatform, string> = {
@@ -14,6 +14,7 @@ export const SOCIAL_PLATFORM_NAMES: Record<SocialPlatform, string> = {
 	x: "X",
 	instagram: "Instagram",
 	facebook: "Facebook",
+	binance: "Binance",
 };
 
 // ── Reclaim (Social Verification) ────────────────────────────────────────────

--- a/src/zkkyc/orchestrators/types.ts
+++ b/src/zkkyc/orchestrators/types.ts
@@ -65,6 +65,17 @@ export interface ReclaimProofResult {
 	readonly sessionId: string;
 }
 
+export interface ReclaimSession {
+	/** The Reclaim session id (empty until known when resuming). */
+	readonly sessionId: string;
+	/** URL to display as a QR code or open as a deep link. Empty when resuming an existing session. */
+	readonly requestUrl: string;
+	/** Triggers the in-app Reclaim flow (browser only) and polls until the proof is ready. Call on user action (e.g. button click). */
+	readonly start: () => ResultAsync<ReclaimProofResult, ZkkycError>;
+	/** Aborts an in-flight polling loop started by `start`. */
+	readonly abort: () => void;
+}
+
 // ── ZK Passport ──────────────────────────────────────────────────────────────
 
 /**
@@ -108,4 +119,59 @@ export interface ZkPassportSession {
 	readonly result: ResultAsync<ZkPassportProofResult, ZkkycError>;
 	/** Aborts the flow. The result promise will reject with ZK_PASSPORT_ABORTED. */
 	readonly abort: () => void;
+}
+
+// ── simple-kyc (hosted passport + liveness wizard) ────────────────────────────
+
+/**
+ * Params for `createSimpleKycFlow`. The app opens the hosted simple-kyc wizard,
+ * which runs onboard → passport → liveness → face match/dedup and, on approval,
+ * redirects back to `redirectUrl` with `?code=<code>&state=<state>`. The app
+ * then calls `resumeSimpleKycFlow` to redeem the code for the EIP-712 attestation.
+ */
+export interface SimpleKycFlowParams {
+	/**
+	 * Base URL exposing the browser-facing `/v1/widget/public-sessions` and
+	 * `/v1/widget/attestation` endpoints — the `kyc-proxy` in a client-only setup
+	 * (e.g. http://localhost:8787). The proxy holds the X-API-Key and forwards to
+	 * simple-kyc's key-gated endpoints.
+	 */
+	readonly baseUrl: string;
+	/** The user's EVM wallet — bound into the attestation and credited on-chain. */
+	readonly walletAddress: Address;
+	/** Tenant slug (one per consuming contract), e.g. "p2p-reputation". */
+	readonly tenant: string;
+	/** Return URL — pass `${window.location.origin}<route>` so each app self-routes. */
+	readonly redirectUrl: string;
+	/**
+	 * ISO-2 country code (e.g. "IN"). Required — the embedded wizard skips the
+	 * country step, so the app must prebind it. Must be one of simple-kyc's
+	 * supported markets (IN, NG, BR, MX, CO, AR, VE, ID).
+	 */
+	readonly country: string;
+	/** Opaque state round-tripped back to the app (CSRF/nonce + page to restore). */
+	readonly state?: string;
+	/** Status callback. */
+	readonly onStatus?: (status: SimpleKycStatus) => void;
+}
+
+export type SimpleKycStatus =
+	| { type: "session_created"; widgetUrl: string }
+	| { type: "redirecting"; widgetUrl: string };
+
+export interface SimpleKycSession {
+	/** The hosted wizard URL to navigate to. */
+	readonly widgetUrl: string;
+	/** Convenience: navigate the browser to the wizard (no-op outside the browser). */
+	readonly redirect: () => void;
+}
+
+/** The on-chain-ready attestation, shaped for `prepareSubmitKycAttestation`. */
+export interface SimpleKycAttestation {
+	readonly nullifier: `0x${string}`;
+	readonly limit: bigint;
+	readonly expiry: bigint;
+	readonly signature: `0x${string}`;
+	/** The opaque unique-human handle (no PII), for app-side bookkeeping. */
+	readonly identityHash?: string;
 }

--- a/src/zkkyc/validation.ts
+++ b/src/zkkyc/validation.ts
@@ -84,3 +84,22 @@ export const ZodZkPassportRegisterParamsSchema = z.object({
 });
 
 export type ZkPassportRegisterParams = z.infer<typeof ZodZkPassportRegisterParamsSchema>;
+
+// ── simple-kyc EIP-712 attestation ───────────────────────────────────────────
+
+export const ZodSimpleKycSubmitParamsSchema = z.object({
+	/** Per-(tenant, identity) Sybil nullifier (bytes32 hex). */
+	nullifier: z.string().refine((v) => /^0x[a-fA-F0-9]{64}$/.test(v), {
+		message: "nullifier must be a bytes32 hex string",
+	}),
+	/** Remaining limit in micro-USDC (part of the signed struct). */
+	limit: z.bigint(),
+	/** Attestation expiry (unix seconds). */
+	expiry: z.bigint(),
+	/** 65-byte secp256k1 signature (hex). */
+	signature: z.string().refine((v) => /^0x[a-fA-F0-9]+$/.test(v), {
+		message: "signature must be a hex string",
+	}),
+});
+
+export type SimpleKycSubmitParams = z.infer<typeof ZodSimpleKycSubmitParamsSchema>;


### PR DESCRIPTION
Registers "binance" across SocialPlatform union, SOCIAL_PLATFORM_NAMES, and DEFAULT_RECLAIM_PROVIDER_IDS so consumers can use Binance as a Reclaim social verification provider.