### PR TITLE
feat: add contract errors with hex selector parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,38 @@ Every write action exposes two methods:
 - **`action.prepare(params)`** — returns a `ResultAsync<PreparedTx, OrdersError>`, where `PreparedTx` is `{ to, data, value, meta }`. No wallet needed. Use this for gasless relayers, multisigs, server-side signing, or anything not wagmi/viem.
 - **`action.execute({ walletClient, waitForReceipt?, ...params })`** — `prepare()` + `walletClient.sendTransaction` + optional `waitForTransactionReceipt`. The fast path when you're signing directly with viem.
 
+## Contract errors
+
+Every revert from the P2P.me Diamond can be decoded to a typed code and a ready-to-display English string.
+
+```ts
+import {
+  parseContractError,
+  getContractErrorMessage,
+} from "@p2pdotme/sdk/orders";
+
+// 1. Decode a raw revert (viem error, hex selector, or nested cause)
+//    → returns a ContractErrorCode string, or null if unknown
+const code = parseContractError(err);
+// e.g. "USERNAME_ALREADY_VERIFIED"
+
+// 2. Get the English UI string for a code (with optional fallback)
+const message = getContractErrorMessage(code);
+// "The social media account's username is already verified"
+
+// Combined — typical usage in an error handler:
+orders.placeOrder.execute(params).match(
+  ({ hash }) => console.log("placed", hash),
+  (err) => {
+    const code    = parseContractError(err.cause);
+    const message = getContractErrorMessage(code);
+    showToast(message); // ready for display
+  },
+);
+```
+
+All three exports — `contractErrors` (name → code map), `hexContractErrors` (4-byte selector → code), and `contractErrorMessages` (code → English string) — are also exported for advanced use cases such as building per-locale translation tables on top.
+
 ## React hooks
 
 All hooks read from the nearest `<SdkProvider>`:

--- a/src/contracts/error-messages.ts
+++ b/src/contracts/error-messages.ts
@@ -1,0 +1,254 @@
+import type { ContractErrorCode } from "./errors";
+
+/**
+ * English UI strings for every contract error code.
+ * Pass a `ContractErrorCode` to `getContractErrorMessage` to get a
+ * human-readable string safe to display directly in the UI.
+ */
+export const contractErrorMessages: Record<ContractErrorCode, string> = {
+	// Access control
+	NOT_ADMIN: "You are not an admin",
+	NOT_SUPER_ADMIN: "You are not a super admin",
+	NOT_AUTHORIZED: "Not authorized",
+	NOT_SELF: "Action can only be performed by yourself",
+	NOT_WHITELISTED: "Not whitelisted",
+	NOT_CIRCLE_ADMIN: "You are not a circle admin",
+
+	// Circle / community management
+	INVALID_NAME: "Invalid name",
+	INVALID_COMMUNITY_URL: "Invalid community URL",
+	INVALID_ADMIN_COMMUNITY_URL: "Invalid admin community URL",
+	ADMIN_ALREADY_HAS_CIRCLE: "Admin already has a circle",
+	CIRCLE_NAME_ALREADY_TAKEN: "Circle name is already taken",
+	P2P_STAKE_CONFIG_NOT_SET: "P2P stake config is not set",
+	INSUFFICIENT_P2P_STAKE: "Insufficient P2P stake",
+	P2P_TOKEN_NOT_SET: "P2P token is not set",
+	P2P_UNSTAKE_REQUEST_PENDING: "A P2P unstake request is already pending",
+	NO_P2P_UNSTAKE_REQUEST: "No P2P unstake request found",
+	P2P_UNSTAKE_COOLDOWN_NOT_PASSED: "P2P unstake cooldown period has not passed",
+	SLASH_AMOUNT_EXCEEDS_STAKE: "Slash amount exceeds stake",
+	CIRCLE_NOT_ACTIVE: "Circle is not active",
+	INVALID_CIRCLE_ID: "Invalid circle ID",
+	CURRENCY_MISMATCH: "Currency mismatch",
+	CIRCLE_FULL: "Circle is full",
+	CIRCLE_ID_MISMATCH: "Circle ID mismatch",
+	DUPLICATE_ACCOUNT_NAME: "Account name already exists",
+	EMPTY_NAME: "Name cannot be empty",
+	ACCOUNT_BOUND_TO_ANOTHER_CIRCLE: "Account is bound to another circle",
+	EXIT_AMOUNT_EXCEEDED_CIRCLE_BALANCE: "Exit amount exceeded circle balance",
+	UNDELEGATION_AMOUNT_TOO_HIGH: "Undelegation amount is too high",
+
+	// Exchange / order lifecycle
+	EXCHANGE_NOT_OPERATIONAL: "Exchange is not operational",
+	ORDER_NOT_PLACED: "Order not placed",
+	ORDER_NOT_PAID: "Order has not been paid",
+	ORDER_STATUS_INVALID: "Order with placed status only can be re-assigned",
+	ORDER_EXPIRED: "Order expired",
+	ORDER_ALREADY_PAID: "Payment address already sent",
+	ORDER_ALREADY_COMPLETED: "Order already marked completed",
+	INVALID_ORDER_TYPE: "Invalid order type",
+	ORDER_TYPE_INCORRECT: "Incorrect order type",
+	ORDER_NOT_ACCEPTED: "Order not placed to be accepted",
+	ORDER_NOT_ASSIGNED: "Order not assigned",
+	ORDER_AMOUNT_EXCEEDS_LIMIT: "Order amount exceeds limit",
+	INVALID_ORDER_AMOUNT: "Invalid order amount",
+	INVALID_ORDER_AMOUNT_TO_COVER_FEE: "Order amount is not enough to cover fee",
+	INVALID_ORDER_ID: "Invalid order ID",
+	ORDER_TOO_EARLY_FOR_REASSIGNMENT: "Order is too early for reassignment",
+	ORDER_TOO_LATE_FOR_REASSIGNMENT: "Order is too late for reassignment",
+	REASSIGNMENT_NOT_REQUIRED: "Reassignment is not required",
+	TIP_ALREADY_GIVEN: "Tip already given",
+	CASHBACK_TRANSFER_FAILED: "Cashback transfer failed",
+
+	// Order limits
+	DAILY_BUY_ORDER_LIMIT_EXCEEDED: "Daily buy order count limit exceeded",
+	MONTHLY_BUY_ORDER_LIMIT_EXCEEDED: "Monthly buy order count limit exceeded",
+	SELL_ORDER_AMOUNT_LIMIT_EXCEEDED: "Sell order amount limit exceeded",
+	BUY_ORDER_AMOUNT_EXCEEDS_LIMIT: "Buy order amount exceeds limit",
+	SELL_ORDER_AMOUNT_EXCEEDS_LIMIT: "Sell order amount exceeds limit",
+	BUY_AMOUNT_EXCEEDS_USDC_LIMIT: "Buy amount exceeds USDC limit",
+	SELL_AMOUNT_EXCEEDS_FIAT_LIMIT: "Sell amount exceeds fiat limit",
+	DAILY_VOLUME_LIMIT_EXCEEDED: "Daily volume limit exceeded",
+	MONTHLY_VOLUME_LIMIT_EXCEEDED: "Monthly volume limit exceeded",
+	USER_YEARLY_VOLUME_LIMIT_EXCEEDED: "Yearly volume limit exceeded",
+
+	// Dispute
+	DISPUTE_TIME_NOT_REACHED: "Dispute can only be raised after 30 minutes of order placement",
+	DISPUTE_TIME_EXPIRED: "Dispute can only be raised after 24 hours of order placement",
+	INVALID_ORDER_STATUS_TO_RAISE_DISPUTE: "Invalid order status to raise dispute",
+	DISPUTE_NOT_RAISED: "Dispute not raised",
+	CANNOT_RAISE_DISPUTE_TWICE: "Cannot raise dispute twice",
+	DISPUTE_ALREADY_SETTLED: "Dispute already settled",
+	TRANSACTION_ID_MISMATCH: "Transaction ID does not match",
+	ACCOUNT_NUMBER_MISMATCH: "Account number does not match",
+	NOT_PAID_BUY_ORDER: "Not a paid buy order",
+
+	// Payment channels
+	PAYMENT_CHANNEL_NOT_FOUND: "Payment channel not found",
+	PAYMENT_CHANNEL_NOT_ACTIVE: "Payment channel not active",
+	PAYMENT_CHANNEL_NOT_APPROVED: "Payment channel not approved",
+	PAYMENT_CHANNEL_NOT_REJECTED: "Payment channel has not been rejected",
+	INVALID_PAYMENT_CHANNEL_ID: "Invalid payment channel ID",
+	DUPLICATE_PAYMENT_CHANNEL: "Duplicate payment channel",
+	OLD_PAYMENT_CHANNEL_NOT_FOUND: "Old payment channel not found",
+	NEW_PAYMENT_CHANNEL_NOT_FOUND: "New payment channel not found",
+	SAME_PAYMENT_CHANNEL: "Old and new payment channels are the same",
+	OLD_PAYMENT_CHANNEL_SHOULD_BE_INACTIVE: "Old payment channel should be inactive",
+	NEW_PAYMENT_CHANNEL_SHOULD_BE_ACTIVE: "New payment channel should be active",
+	ONGOING_ORDER_ON_PAYMENT_CHANNEL: "There is an ongoing order on this payment channel",
+	UPI_ALREADY_SENT: "Payment address already sent",
+	INVALID_ORDER_UPI: "Invalid order payment address",
+	NO_FIAT_LIQUIDITY: "No fiat liquidity on exchange to complete order",
+
+	// Merchant
+	NOT_ENOUGH_ELIGIBLE_MERCHANTS: "Not enough eligible merchants",
+	MERCHANT_NOT_REGISTERED: "Merchant is not registered",
+	MERCHANT_NOT_APPROVED: "Merchant is not approved",
+	MERCHANT_ALREADY_REGISTERED: "Merchant already registered",
+	MERCHANT_ALREADY_REJECTED: "Merchant already rejected",
+	MERCHANT_BLACKLISTED: "Merchant blacklisted",
+	MERCHANT_NOT_BLACKLISTED: "Merchant not blacklisted",
+	MERCHANT_ALREADY_BLACKLISTED: "Merchant already blacklisted",
+	MERCHANT_HAS_ONGOING_ORDERS: "Merchant has ongoing orders",
+	MERCHANT_NOT_FULLFILLED_ELIGIBILITY_THRESHOLD: "Merchant has not fulfilled eligibility threshold",
+	INVALID_MERCHANT: "Invalid merchant",
+
+	// Staking / unstaking
+	STAKE_AMOUNT_TOO_LOW: "Stake amount is too low",
+	ADDITIONAL_STAKE_NOT_ALLOWED: "Additional stake is not allowed",
+	UNSTAKE_REQUEST_PENDING: "Unstake request is already pending",
+	UNSTAKE_REQUEST_NOT_PENDING: "No pending unstake request",
+	UNSTAKE_AMOUNT_EXCEEDED: "Unstake amount exceeded",
+	ZERO_UNSTAKE_AMOUNT: "Unstake amount cannot be zero",
+	NO_WITHDRAWABLE_AMOUNT: "No withdrawable amount",
+	NO_STAKE: "No stake found",
+	NO_STAKERS: "No stakers found",
+	INSUFFICIENT_STAKED_AMOUNT: "Insufficient staked amount",
+	COOLDOWN_NOT_PASSED: "Cooldown period has not passed",
+	CLAIMABLE_REWARDS_NOT_AVAILABLE: "No rewards to claim",
+
+	// Delegation
+	EXIT_WOULD_BREACH_DELEGATION_INVARIANT: "Exit would breach delegation invariant",
+	AGGREGATE_DELEGATION_EXCEEDS_TOTAL_STAKED: "Aggregate delegation exceeds total staked",
+	INSUFFICIENT_MERCHANT_REWARDS: "Insufficient merchant rewards",
+
+	// Migration
+	INVALID_MIGRATION_STATUS: "Invalid migration status",
+	MIGRATION_REQUEST_NOT_PENDING: "No pending migration request",
+	MIGRATION_ALREADY_REQUESTED: "Migration already requested",
+
+	// Token / currency
+	TOKEN_ALREADY_EXISTS: "Token already exists",
+	TOKEN_NOT_FOUND: "Token not found",
+	TOKEN_EMPTY: "Token is empty",
+	CURRENCY_NOT_SUPPORTED: "Currency not supported",
+	INVALID_CURRENCY: "Invalid currency",
+
+	// USDC / transfer
+	USDC_TRANSFER_FAILED: "USDC transfer failed",
+	USDC_TRANSFER_FAILED_WITH_ERROR_MESSAGE: "USDC transfer failed with error message",
+	USDC_TRANSFER_FAILED_WITH_PANIC: "USDC transfer failed with panic",
+	INSUFFICIENT_ALLOWANCE: "Insufficient USDC allowance",
+
+	// ZK Passport
+	ZK_PASSPORT_VERIFIER_NOT_SET: "ZK Passport verifier not set",
+	ZK_PASSPORT_DOMAIN_EMPTY: "ZK Passport domain is empty",
+	ZK_PASSPORT_SCOPE_EMPTY: "ZK Passport scope is empty",
+	PASSPORT_ALREADY_VERIFIED: "Passport already verified",
+	ZK_PASSPORT_PROOF_INVALID: "ZK Passport proof is invalid",
+	ZK_PASSPORT_IDENTIFIER_ALREADY_VERIFIED: "ZK Passport identifier already verified",
+	ZK_PASSPORT_INVALID_SCOPE: "ZK Passport invalid scope",
+	ZK_PASSPORT_UNEXPECTED_SENDER: "ZK Passport unexpected sender",
+	ZK_PASSPORT_AGE_BELOW_MINIMUM: "ZK Passport age below minimum",
+	ZK_PASSPORT_MIN_AGE_TOO_HIGH: "ZK Passport minimum age too high",
+
+	// Chainlink / oracle
+	UNEXPECTED_REQUEST_ID: "Unexpected request ID",
+	ONLY_ROUTER_CAN_FULFILL: "Only the router can fulfill this request",
+	REQUEST_FAILED: "Request failed",
+	SOURCE_CODE_MISMATCH: "Source code mismatch",
+	ZERO_MARKET_PRICE: "Market price cannot be zero",
+	INVALID_COMPUTED_PRICES: "Invalid computed prices",
+	NOT_PRICE_UPDATER_FOR_CURRENCY: "Not the price updater for this currency",
+	THRESHOLD_NOT_CONFIGURED: "Threshold not configured",
+	SLIPPAGE_EXCEEDED: "Slippage exceeded",
+
+	// Reputation / verification
+	USER_HAS_NO_REPUTATION:
+		"Kindly do ZK social verifications and increase your limits to place more orders",
+	ZERO_REPUTATION_POINTS: "Cannot place buy orders with 0 reputation points",
+	NO_REPUTATION: "No reputation points",
+	INSUFFICIENT_RP: "Insufficient reputation points",
+	NULLIFIER_ALREADY_VERIFIED: "Nullifier already verified",
+	VERIFICATION_FAILED: "Verification failed",
+	INVALID_SOCIAL_PLATFORM: "Invalid social media platform",
+	SOCIAL_ALREADY_VERIFIED: "Social already verified",
+	YEAR_FIELD_NOT_IN_PROOF: "Year field not found in proof",
+	USER_ID_FIELD_NOT_IN_PROOF: "User ID field not found in proof",
+	USER_ID_ALREADY_VERIFIED: "The social media account's user ID is already verified",
+	USERNAME_ALREADY_VERIFIED: "The social media account's username is already verified",
+	USERNAME_NOT_IN_PROOF: "Username field not found in proof",
+	LINKEDIN_ONLY_RP_UPDATES: "LinkedIn only supports RP updates",
+	FACEBOOK_ONLY_RP_UPDATES: "Facebook only supports RP updates",
+
+	// Voting / referral
+	ALREADY_REFERRED: "Already referred",
+	SELF_REFERRAL_NOT_ALLOWED: "Self referral not allowed",
+	NOT_ELIGIBLE_TO_REFER: "Not eligible to refer",
+	MERCHANT_MONTHLY_REFERRAL_LIMIT_REACHED: "Merchant monthly referral limit reached",
+	NO_RECOMMENDER: "No recommender found",
+	RECOMMENDATION_ALREADY_CLAIMED: "Recommendation already claimed",
+	CANNOT_VOTE_YOURSELF: "Cannot vote yourself",
+	VOTES_PER_EPOCH_EXCEEDED: "Votes per epoch exceeded",
+	ALREADY_VOTED: "Already voted",
+	FUNCTION_NOT_FOUND: "Function not found",
+
+	// Campaign
+	CAMPAIGN_NOT_ACTIVE: "Campaign is not active",
+	INVALID_MANAGER_DETAILS: "Invalid manager details",
+	UNCLAIMED_REWARDS_EXIST: "Unclaimed rewards exist",
+	REWARD_ALREADY_CLAIMED: "Reward already claimed",
+	ONLY_NEW_USERS_ALLOWED: "Only new users allowed",
+	MANAGER_NOT_FOUND: "Manager not found",
+	MANAGER_INACTIVE: "Manager is inactive",
+	NO_REWARDS: "No rewards",
+	INVALID_CAMPAIGN_ID: "Invalid campaign ID",
+	CANNOT_CLAIM_REVENUE_FOR_CURRENT_MONTH: "Cannot claim revenue for the current month",
+
+	// Referral reward config
+	REWARD_PERCENTAGE_TOO_HIGH: "Reward percentage is too high",
+
+	// Signature / nonce
+	NONCE_ALREADY_USED: "Nonce already used",
+	SIGNATURE_VALIDATION_FAILED: "Signature validation failed",
+
+	// Misc
+	INVALID_ADDRESS: "Invalid address",
+	INVALID_BLOCK_AMOUNT: "Invalid block amount",
+	INVALID_AMOUNT: "Invalid amount",
+	INVALID_INPUT: "Invalid input",
+	INVALID_STATUS_TRANSITION: "Invalid status transition",
+	ARRAY_LENGTH_MISMATCH: "Array length mismatch",
+	USER_IS_BLACKLISTED: "User is blacklisted",
+	ZERO_ADDRESS: "Zero address",
+	REENTRANCY_GUARD: "Reentrancy detected",
+	BATCH_TOO_LARGE: "Batch size too large",
+	UNDERFLOW_SUBTRACTION: "Cannot subtract more than balance",
+	TARGET_LONGER_THAN_DATA: "Target is longer than data",
+};
+
+/**
+ * Returns a human-readable English string for the given `ContractErrorCode`,
+ * or a generic fallback message if the code is not recognised.
+ *
+ * @example
+ * const msg = getContractErrorMessage("USERNAME_ALREADY_VERIFIED");
+ * // "The social media account's username is already verified"
+ */
+export function getContractErrorMessage(
+	code: ContractErrorCode | string | null | undefined,
+	fallback = "Something went wrong. Please try again.",
+): string {
+	if (!code) return fallback;
+	return contractErrorMessages[code as ContractErrorCode] ?? fallback;
+}

--- a/src/contracts/errors.ts
+++ b/src/contracts/errors.ts
@@ -1,0 +1,527 @@
+/**
+ * Centralized contract error definitions mirroring `contracts/libraries/Errors.sol`.
+ * Maps Solidity custom error names and their 4-byte selectors to human-readable codes.
+ */
+
+export const contractErrors = {
+	// Access control
+	NotAdmin: "NOT_ADMIN",
+	NotSuperAdmin: "NOT_SUPER_ADMIN",
+	NotAuthorized: "NOT_AUTHORIZED",
+	NotSelf: "NOT_SELF",
+	NotWhitelisted: "NOT_WHITELISTED",
+	NotCircleAdmin: "NOT_CIRCLE_ADMIN",
+
+	// Circle / community management
+	InvalidName: "INVALID_NAME",
+	InvalidCommunityUrl: "INVALID_COMMUNITY_URL",
+	InvalidAdminCommunityUrl: "INVALID_ADMIN_COMMUNITY_URL",
+	AdminAlreadyHasCircle: "ADMIN_ALREADY_HAS_CIRCLE",
+	CircleNameAlreadyTaken: "CIRCLE_NAME_ALREADY_TAKEN",
+	P2PStakeConfigNotSet: "P2P_STAKE_CONFIG_NOT_SET",
+	InsufficientP2PStake: "INSUFFICIENT_P2P_STAKE",
+	P2PTokenNotSet: "P2P_TOKEN_NOT_SET",
+	P2PUnstakeRequestPending: "P2P_UNSTAKE_REQUEST_PENDING",
+	NoP2PUnstakeRequest: "NO_P2P_UNSTAKE_REQUEST",
+	P2PUnstakeCooldownNotPassed: "P2P_UNSTAKE_COOLDOWN_NOT_PASSED",
+	SlashAmountExceedsStake: "SLASH_AMOUNT_EXCEEDS_STAKE",
+	CircleNotActive: "CIRCLE_NOT_ACTIVE",
+	InvalidCircleId: "INVALID_CIRCLE_ID",
+	CurrencyMismatch: "CURRENCY_MISMATCH",
+	CircleFull: "CIRCLE_FULL",
+	CircleIdMismatch: "CIRCLE_ID_MISMATCH",
+	DuplicateAccountName: "DUPLICATE_ACCOUNT_NAME",
+	EmptyName: "EMPTY_NAME",
+	AccountBoundToAnotherCircle: "ACCOUNT_BOUND_TO_ANOTHER_CIRCLE",
+	ExitAmountExceededCircleBalance: "EXIT_AMOUNT_EXCEEDED_CIRCLE_BALANCE",
+	UndelegationAmountTooHigh: "UNDELEGATION_AMOUNT_TOO_HIGH",
+
+	// Exchange / order lifecycle
+	ExchangeNotOperational: "EXCHANGE_NOT_OPERATIONAL",
+	OrderNotPlaced: "ORDER_NOT_PLACED",
+	OrderNotPaid: "ORDER_NOT_PAID",
+	OrderStatusInvalid: "ORDER_STATUS_INVALID",
+	OrderExpired: "ORDER_EXPIRED",
+	OrderAlreadyPaid: "ORDER_ALREADY_PAID",
+	OrderAlreadyCompleted: "ORDER_ALREADY_COMPLETED",
+	InvalidOrderType: "INVALID_ORDER_TYPE",
+	OrderTypeIncorrect: "ORDER_TYPE_INCORRECT",
+	OrderNotAccepted: "ORDER_NOT_ACCEPTED",
+	OrderNotAssigned: "ORDER_NOT_ASSIGNED",
+	OrderAmountExceedsLimit: "ORDER_AMOUNT_EXCEEDS_LIMIT",
+	InvalidOrderAmount: "INVALID_ORDER_AMOUNT",
+	InvalidOrderAmountToCoverFee: "INVALID_ORDER_AMOUNT_TO_COVER_FEE",
+	InvalidOrderId: "INVALID_ORDER_ID",
+	OrderTooEarlyForReassignment: "ORDER_TOO_EARLY_FOR_REASSIGNMENT",
+	OrderTooLateForReassignment: "ORDER_TOO_LATE_FOR_REASSIGNMENT",
+	ReAssignmentNotRequired: "REASSIGNMENT_NOT_REQUIRED",
+	TipAlreadyGiven: "TIP_ALREADY_GIVEN",
+	CashbackTransferFailed: "CASHBACK_TRANSFER_FAILED",
+
+	// Order limits
+	DailyBuyOrderLimitExceeded: "DAILY_BUY_ORDER_LIMIT_EXCEEDED",
+	MonthlyBuyOrderLimitExceeded: "MONTHLY_BUY_ORDER_LIMIT_EXCEEDED",
+	SellOrderAmountLimitExceeded: "SELL_ORDER_AMOUNT_LIMIT_EXCEEDED",
+	BuyOrderAmountExceedsLimit: "BUY_ORDER_AMOUNT_EXCEEDS_LIMIT",
+	SellOrderAmountExceedsLimit: "SELL_ORDER_AMOUNT_EXCEEDS_LIMIT",
+	BuyAmountExceedsUsdcLimit: "BUY_AMOUNT_EXCEEDS_USDC_LIMIT",
+	SellAmountExceedsFiatLimit: "SELL_AMOUNT_EXCEEDS_FIAT_LIMIT",
+	DailyVolumeLimitExceeded: "DAILY_VOLUME_LIMIT_EXCEEDED",
+	MonthlyVolumeLimitExceeded: "MONTHLY_VOLUME_LIMIT_EXCEEDED",
+	UserYearlyVolumeLimitExceeded: "USER_YEARLY_VOLUME_LIMIT_EXCEEDED",
+
+	// Dispute
+	DisputeTimeNotReached: "DISPUTE_TIME_NOT_REACHED",
+	DisputeTimeExpired: "DISPUTE_TIME_EXPIRED",
+	InvalidOrderStatusToRaiseDispute: "INVALID_ORDER_STATUS_TO_RAISE_DISPUTE",
+	DisputeNotRaised: "DISPUTE_NOT_RAISED",
+	CannotRaiseDisputeTwice: "CANNOT_RAISE_DISPUTE_TWICE",
+	DisputeAlreadySettled: "DISPUTE_ALREADY_SETTLED",
+	TransactionIdMismatch: "TRANSACTION_ID_MISMATCH",
+	AccountNumberMismatch: "ACCOUNT_NUMBER_MISMATCH",
+	NotPaidBuyOrder: "NOT_PAID_BUY_ORDER",
+
+	// Payment channels
+	PaymentChannelNotFound: "PAYMENT_CHANNEL_NOT_FOUND",
+	PaymentChannelNotActive: "PAYMENT_CHANNEL_NOT_ACTIVE",
+	PaymentChannelNotApproved: "PAYMENT_CHANNEL_NOT_APPROVED",
+	PaymentChannelNotRejected: "PAYMENT_CHANNEL_NOT_REJECTED",
+	InvalidPaymentChannelId: "INVALID_PAYMENT_CHANNEL_ID",
+	DuplicatePaymentChannel: "DUPLICATE_PAYMENT_CHANNEL",
+	OldPaymentChannelNotFound: "OLD_PAYMENT_CHANNEL_NOT_FOUND",
+	NewPaymentChannelNotFound: "NEW_PAYMENT_CHANNEL_NOT_FOUND",
+	SamePaymentChannel: "SAME_PAYMENT_CHANNEL",
+	OldPaymentChannelShouldBeInactive: "OLD_PAYMENT_CHANNEL_SHOULD_BE_INACTIVE",
+	NewPaymentChannelShouldBeActive: "NEW_PAYMENT_CHANNEL_SHOULD_BE_ACTIVE",
+	OngoingOrderOnPaymentChannel: "ONGOING_ORDER_ON_PAYMENT_CHANNEL",
+	UpiAlreadySent: "UPI_ALREADY_SENT",
+	InvalidOrderUpi: "INVALID_ORDER_UPI",
+	NoFiatLiquidity: "NO_FIAT_LIQUIDITY",
+
+	// Merchant
+	NotEnoughEligibleMerchants: "NOT_ENOUGH_ELIGIBLE_MERCHANTS",
+	MerchantNotRegistered: "MERCHANT_NOT_REGISTERED",
+	MerchantNotApproved: "MERCHANT_NOT_APPROVED",
+	MerchantAlreadyRegistered: "MERCHANT_ALREADY_REGISTERED",
+	MerchantAlreadyRejected: "MERCHANT_ALREADY_REJECTED",
+	MerchantBlacklisted: "MERCHANT_BLACKLISTED",
+	MerchantNotBlacklisted: "MERCHANT_NOT_BLACKLISTED",
+	MerchantAlreadyBlacklisted: "MERCHANT_ALREADY_BLACKLISTED",
+	MerchantHasOngoingOrders: "MERCHANT_HAS_ONGOING_ORDERS",
+	MerchantNotFullfilledEligibilityThreshold: "MERCHANT_NOT_FULLFILLED_ELIGIBILITY_THRESHOLD",
+	InvalidMerchant: "INVALID_MERCHANT",
+
+	// Staking / unstaking
+	StakeAmountTooLow: "STAKE_AMOUNT_TOO_LOW",
+	AdditionalStakeNotAllowed: "ADDITIONAL_STAKE_NOT_ALLOWED",
+	UnstakeRequestPending: "UNSTAKE_REQUEST_PENDING",
+	UnstakeRequestNotPending: "UNSTAKE_REQUEST_NOT_PENDING",
+	UnstakeAmountExceeded: "UNSTAKE_AMOUNT_EXCEEDED",
+	ZeroUnstakeAmount: "ZERO_UNSTAKE_AMOUNT",
+	NoWithdrawableAmount: "NO_WITHDRAWABLE_AMOUNT",
+	NoStake: "NO_STAKE",
+	NoStakers: "NO_STAKERS",
+	InsufficientStakedAmount: "INSUFFICIENT_STAKED_AMOUNT",
+	CooldownNotPassed: "COOLDOWN_NOT_PASSED",
+	ClaimableRewardsNotAvailable: "CLAIMABLE_REWARDS_NOT_AVAILABLE",
+
+	// Delegation
+	ExitWouldBreachDelegationInvariant: "EXIT_WOULD_BREACH_DELEGATION_INVARIANT",
+	AggregateDelegationExceedsTotalStaked: "AGGREGATE_DELEGATION_EXCEEDS_TOTAL_STAKED",
+	InsufficientMerchantRewards: "INSUFFICIENT_MERCHANT_REWARDS",
+
+	// Migration
+	InvalidMigrationStatus: "INVALID_MIGRATION_STATUS",
+	MigrationRequestNotPending: "MIGRATION_REQUEST_NOT_PENDING",
+	MigrationAlreadyRequested: "MIGRATION_ALREADY_REQUESTED",
+
+	// Token / currency
+	TokenAlreadyExists: "TOKEN_ALREADY_EXISTS",
+	TokenNotFound: "TOKEN_NOT_FOUND",
+	TokenEmpty: "TOKEN_EMPTY",
+	CurrencyNotSupported: "CURRENCY_NOT_SUPPORTED",
+	InvalidCurrency: "INVALID_CURRENCY",
+
+	// USDC / transfer
+	UsdtTransferFailed: "USDC_TRANSFER_FAILED",
+	UsdtTransferFailedWithErrorMessage: "USDC_TRANSFER_FAILED_WITH_ERROR_MESSAGE",
+	UsdtTransferFailedWithPanic: "USDC_TRANSFER_FAILED_WITH_PANIC",
+	InsufficientAllowance: "INSUFFICIENT_ALLOWANCE",
+
+	// ZK Passport
+	ZKPassportVerifierNotSet: "ZK_PASSPORT_VERIFIER_NOT_SET",
+	ZKPassportDomainEmpty: "ZK_PASSPORT_DOMAIN_EMPTY",
+	ZKPassportScopeEmpty: "ZK_PASSPORT_SCOPE_EMPTY",
+	PassportAlreadyVerified: "PASSPORT_ALREADY_VERIFIED",
+	ZKPassportProofInvalid: "ZK_PASSPORT_PROOF_INVALID",
+	ZKPassportIdentifierAlreadyVerified: "ZK_PASSPORT_IDENTIFIER_ALREADY_VERIFIED",
+	ZKPassportInvalidScope: "ZK_PASSPORT_INVALID_SCOPE",
+	ZKPassportUnexpectedSender: "ZK_PASSPORT_UNEXPECTED_SENDER",
+	ZKPassportAgeBelowMinimum: "ZK_PASSPORT_AGE_BELOW_MINIMUM",
+	ZKPassportMinAgeTooHigh: "ZK_PASSPORT_MIN_AGE_TOO_HIGH",
+
+	// Chainlink / oracle
+	UnexpectedRequestId: "UNEXPECTED_REQUEST_ID",
+	OnlyRouterCanFulfill: "ONLY_ROUTER_CAN_FULFILL",
+	RequestFailed: "REQUEST_FAILED",
+	SourceCodeMismatch: "SOURCE_CODE_MISMATCH",
+	ZeroMarketPrice: "ZERO_MARKET_PRICE",
+	InvalidComputedPrices: "INVALID_COMPUTED_PRICES",
+	NotPriceUpdaterForCurrency: "NOT_PRICE_UPDATER_FOR_CURRENCY",
+	ThresholdNotConfigured: "THRESHOLD_NOT_CONFIGURED",
+	SlippageExceeded: "SLIPPAGE_EXCEEDED",
+
+	// Reputation / verification
+	UserHasNoReputation: "USER_HAS_NO_REPUTATION",
+	ZeroReputationPoints: "ZERO_REPUTATION_POINTS",
+	NoReputation: "NO_REPUTATION",
+	InsufficientRP: "INSUFFICIENT_RP",
+	NullifierAlreadyVerified: "NULLIFIER_ALREADY_VERIFIED",
+	VerificationFailed: "VERIFICATION_FAILED",
+	InvalidSocialPlatform: "INVALID_SOCIAL_PLATFORM",
+	SocialAlreadyVerified: "SOCIAL_ALREADY_VERIFIED",
+	YearFieldNotInProof: "YEAR_FIELD_NOT_IN_PROOF",
+	UserIdFieldNotInProof: "USER_ID_FIELD_NOT_IN_PROOF",
+	UserIdAlreadyVerified: "USER_ID_ALREADY_VERIFIED",
+	UsernameAlreadyVerified: "USERNAME_ALREADY_VERIFIED",
+	UsernameNotInProof: "USERNAME_NOT_IN_PROOF",
+	LinkedInOnlyRpUpdates: "LINKEDIN_ONLY_RP_UPDATES",
+	FacebookOnlyRpUpdates: "FACEBOOK_ONLY_RP_UPDATES",
+
+	// Voting / referral
+	AlreadyReferred: "ALREADY_REFERRED",
+	SelfReferralNotAllowed: "SELF_REFERRAL_NOT_ALLOWED",
+	NotEligibleToRefer: "NOT_ELIGIBLE_TO_REFER",
+	MerchantMonthlyReferralLimitReached: "MERCHANT_MONTHLY_REFERRAL_LIMIT_REACHED",
+	NoRecommender: "NO_RECOMMENDER",
+	RecommendationAlreadyClaimed: "RECOMMENDATION_ALREADY_CLAIMED",
+	CannotVoteYourself: "CANNOT_VOTE_YOURSELF",
+	VotesPerEpochExceeded: "VOTES_PER_EPOCH_EXCEEDED",
+	AlreadyVoted: "ALREADY_VOTED",
+	FunctionNotFound: "FUNCTION_NOT_FOUND",
+
+	// Campaign
+	CampaignNotActive: "CAMPAIGN_NOT_ACTIVE",
+	InvalidManagerDetails: "INVALID_MANAGER_DETAILS",
+	UnclaimedRewardsExist: "UNCLAIMED_REWARDS_EXIST",
+	RewardAlreadyClaimed: "REWARD_ALREADY_CLAIMED",
+	OnlyNewUsersAllowed: "ONLY_NEW_USERS_ALLOWED",
+	ManagerNotFound: "MANAGER_NOT_FOUND",
+	ManagerInactive: "MANAGER_INACTIVE",
+	NoRewards: "NO_REWARDS",
+	InvalidCampaignId: "INVALID_CAMPAIGN_ID",
+	CannotClaimRevenueForCurrentMonth: "CANNOT_CLAIM_REVENUE_FOR_CURRENT_MONTH",
+
+	// Referral reward config
+	RewardPercentageTooHigh: "REWARD_PERCENTAGE_TOO_HIGH",
+
+	// Signature / nonce
+	NonceAlreadyUsed: "NONCE_ALREADY_USED",
+	SignatureValidationFailed: "SIGNATURE_VALIDATION_FAILED",
+
+	// Misc
+	InvalidAddress: "INVALID_ADDRESS",
+	InvalidBlockAmount: "INVALID_BLOCK_AMOUNT",
+	InvalidAmount: "INVALID_AMOUNT",
+	InvalidInput: "INVALID_INPUT",
+	InvalidStatusTransition: "INVALID_STATUS_TRANSITION",
+	ArrayLengthMismatch: "ARRAY_LENGTH_MISMATCH",
+	UserIsBlacklisted: "USER_IS_BLACKLISTED",
+	ZeroAddress: "ZERO_ADDRESS",
+	ReentrancyGuard: "REENTRANCY_GUARD",
+	BatchTooLarge: "BATCH_TOO_LARGE",
+	UnderflowSubtraction: "UNDERFLOW_SUBTRACTION",
+	TargetLongerThanData: "TARGET_LONGER_THAN_DATA",
+} as const;
+
+export type ContractErrorCode = (typeof contractErrors)[keyof typeof contractErrors];
+
+/** Maps 4-byte Solidity custom error selectors to their error codes. */
+export const hexContractErrors: Record<string, ContractErrorCode> = {
+	// Access control
+	"0x7bfa4b9f": contractErrors.NotAdmin,
+	"0x16c726b1": contractErrors.NotSuperAdmin,
+	"0xea8e4eb5": contractErrors.NotAuthorized,
+	"0x29c3b7ee": contractErrors.NotSelf,
+	"0x584a7938": contractErrors.NotWhitelisted,
+	"0xa8143fbc": contractErrors.NotCircleAdmin,
+
+	// Circle / community management
+	"0x430f13b3": contractErrors.InvalidName,
+	"0xe7cbf75a": contractErrors.InvalidCommunityUrl,
+	"0x3762bfee": contractErrors.InvalidAdminCommunityUrl,
+	"0x201c1ffc": contractErrors.AdminAlreadyHasCircle,
+	"0x6540a51d": contractErrors.CircleNameAlreadyTaken,
+	"0xcadc6786": contractErrors.P2PStakeConfigNotSet,
+	"0x78317f44": contractErrors.InsufficientP2PStake,
+	"0x18eda032": contractErrors.P2PTokenNotSet,
+	"0xdab11ea6": contractErrors.P2PUnstakeRequestPending,
+	"0xeb1ce40b": contractErrors.NoP2PUnstakeRequest,
+	"0xbf2d0ba1": contractErrors.P2PUnstakeCooldownNotPassed,
+	"0x06b663af": contractErrors.SlashAmountExceedsStake,
+	"0xff9b022c": contractErrors.CircleNotActive,
+	"0x3d90c0a6": contractErrors.InvalidCircleId,
+	"0xfb42a67d": contractErrors.CurrencyMismatch,
+	"0xf2775265": contractErrors.CircleFull,
+	"0x784b6c3c": contractErrors.CircleIdMismatch,
+	"0xee240e49": contractErrors.DuplicateAccountName,
+	"0x2ef13105": contractErrors.EmptyName,
+	"0x1b5433c8": contractErrors.AccountBoundToAnotherCircle,
+	"0x549e2555": contractErrors.ExitAmountExceededCircleBalance,
+	"0x865b21e1": contractErrors.UndelegationAmountTooHigh,
+
+	// Exchange / order lifecycle
+	"0x4bbac5de": contractErrors.ExchangeNotOperational,
+	"0x58db8ed6": contractErrors.OrderNotPlaced,
+	"0x1e3b9629": contractErrors.OrderNotPaid,
+	"0x181b1b2e": contractErrors.OrderStatusInvalid,
+	"0xc56873ba": contractErrors.OrderExpired,
+	"0x7f61b868": contractErrors.OrderAlreadyPaid,
+	"0x03683687": contractErrors.OrderAlreadyCompleted,
+	"0x688c176f": contractErrors.InvalidOrderType,
+	"0x2e757a60": contractErrors.OrderTypeIncorrect,
+	"0x6b1b90b4": contractErrors.OrderNotAccepted,
+	"0x1775c43e": contractErrors.OrderNotAssigned,
+	"0xf42e41a1": contractErrors.OrderAmountExceedsLimit,
+	"0x93845d68": contractErrors.InvalidOrderAmount,
+	"0x138b9d5a": contractErrors.InvalidOrderAmountToCoverFee,
+	"0x5d706033": contractErrors.InvalidOrderId,
+	"0xbb776720": contractErrors.OrderTooEarlyForReassignment,
+	"0x20d5910f": contractErrors.OrderTooLateForReassignment,
+	"0xccd87bf0": contractErrors.ReAssignmentNotRequired,
+	"0xb20277f8": contractErrors.TipAlreadyGiven,
+	"0xdf9f707c": contractErrors.CashbackTransferFailed,
+
+	// Order limits
+	"0xe595a7bf": contractErrors.DailyBuyOrderLimitExceeded,
+	"0x675dbc86": contractErrors.MonthlyBuyOrderLimitExceeded,
+	"0x64301cb8": contractErrors.SellOrderAmountLimitExceeded,
+	"0x91da284f": contractErrors.BuyOrderAmountExceedsLimit,
+	"0xb407b9ec": contractErrors.SellOrderAmountExceedsLimit,
+	"0x4b29cf0a": contractErrors.BuyAmountExceedsUsdcLimit,
+	"0xbba2edf9": contractErrors.SellAmountExceedsFiatLimit,
+	"0x7e2ee654": contractErrors.DailyVolumeLimitExceeded,
+	"0x49de1789": contractErrors.MonthlyVolumeLimitExceeded,
+	"0xb14a1ff3": contractErrors.UserYearlyVolumeLimitExceeded,
+
+	// Dispute
+	"0x07a2454f": contractErrors.DisputeTimeNotReached,
+	"0xb28c3e29": contractErrors.DisputeTimeExpired,
+	"0x2a829f07": contractErrors.InvalidOrderStatusToRaiseDispute,
+	"0x88d039ce": contractErrors.DisputeNotRaised,
+	"0x3764a75c": contractErrors.CannotRaiseDisputeTwice,
+	"0x866e9f89": contractErrors.DisputeAlreadySettled,
+	"0x6131d13d": contractErrors.TransactionIdMismatch,
+	"0x8ec051b8": contractErrors.AccountNumberMismatch,
+	"0xf8bfad32": contractErrors.NotPaidBuyOrder,
+
+	// Payment channels
+	"0x552ff5ec": contractErrors.PaymentChannelNotFound,
+	"0xfccd93cf": contractErrors.PaymentChannelNotActive,
+	"0x6764f4d6": contractErrors.PaymentChannelNotApproved,
+	"0xab284291": contractErrors.PaymentChannelNotRejected,
+	"0x99c8ef4d": contractErrors.InvalidPaymentChannelId,
+	"0x0569ab3e": contractErrors.DuplicatePaymentChannel,
+	"0xff4f83ca": contractErrors.OldPaymentChannelNotFound,
+	"0xb1198199": contractErrors.NewPaymentChannelNotFound,
+	"0xc905b99a": contractErrors.SamePaymentChannel,
+	"0xcedb41f1": contractErrors.OldPaymentChannelShouldBeInactive,
+	"0x487add97": contractErrors.NewPaymentChannelShouldBeActive,
+	"0x6d4c3f9e": contractErrors.OngoingOrderOnPaymentChannel,
+	"0xc1654697": contractErrors.UpiAlreadySent,
+	"0xaa60ec26": contractErrors.InvalidOrderUpi,
+	"0x81c2b982": contractErrors.NoFiatLiquidity,
+
+	// Merchant
+	"0x5d04ff4c": contractErrors.NotEnoughEligibleMerchants,
+	"0xa6af7ebe": contractErrors.MerchantNotRegistered,
+	"0x7290a612": contractErrors.MerchantNotApproved,
+	"0xf4a1e014": contractErrors.MerchantAlreadyRegistered,
+	"0x8713aaba": contractErrors.MerchantAlreadyRejected,
+	"0x9ae55bc7": contractErrors.MerchantBlacklisted,
+	"0x0ee0b659": contractErrors.MerchantNotBlacklisted,
+	"0x5f765689": contractErrors.MerchantAlreadyBlacklisted,
+	"0x9c54e5a8": contractErrors.MerchantHasOngoingOrders,
+	"0x70d753bd": contractErrors.MerchantNotFullfilledEligibilityThreshold,
+	"0xc0b6c919": contractErrors.InvalidMerchant,
+
+	// Staking / unstaking
+	"0x3fd2347e": contractErrors.StakeAmountTooLow,
+	"0x703cde0a": contractErrors.AdditionalStakeNotAllowed,
+	"0xa9de99ae": contractErrors.UnstakeRequestPending,
+	"0x0b7c70f3": contractErrors.UnstakeRequestNotPending,
+	"0xe665491f": contractErrors.UnstakeAmountExceeded,
+	"0x2d3087f9": contractErrors.ZeroUnstakeAmount,
+	"0x1b1d7861": contractErrors.NoWithdrawableAmount,
+	"0xcacf989a": contractErrors.NoStake,
+	"0x21311aa3": contractErrors.NoStakers,
+	"0xd06ff88e": contractErrors.InsufficientStakedAmount,
+	"0x9ab7872d": contractErrors.CooldownNotPassed,
+	"0x73380d99": contractErrors.ClaimableRewardsNotAvailable,
+
+	// Delegation
+	"0xec4b3ce6": contractErrors.ExitWouldBreachDelegationInvariant,
+	"0x8f90a426": contractErrors.AggregateDelegationExceedsTotalStaked,
+	"0x2cc11576": contractErrors.InsufficientMerchantRewards,
+
+	// Migration
+	"0x92aa7d0f": contractErrors.InvalidMigrationStatus,
+	"0x7ff47425": contractErrors.MigrationRequestNotPending,
+	"0x88ddec46": contractErrors.MigrationAlreadyRequested,
+
+	// Token / currency
+	"0xc991cbb1": contractErrors.TokenAlreadyExists,
+	"0xcbdb7b30": contractErrors.TokenNotFound,
+	"0x9f11a53f": contractErrors.TokenEmpty,
+	"0x02a6fdd2": contractErrors.CurrencyNotSupported,
+	"0xf5993428": contractErrors.InvalidCurrency,
+
+	// USDC / transfer
+	"0x149f9fca": contractErrors.UsdtTransferFailed,
+	"0x47bfece5": contractErrors.UsdtTransferFailedWithErrorMessage,
+	"0x279bbc0c": contractErrors.UsdtTransferFailedWithPanic,
+	"0xfb8f41b2": contractErrors.InsufficientAllowance,
+
+	// ZK Passport
+	"0xfd8d4a6d": contractErrors.ZKPassportVerifierNotSet,
+	"0xb87078f9": contractErrors.ZKPassportDomainEmpty,
+	"0x5eadc4c2": contractErrors.ZKPassportScopeEmpty,
+	"0x7642fe15": contractErrors.PassportAlreadyVerified,
+	"0x1fa24b35": contractErrors.ZKPassportProofInvalid,
+	"0x36bdb7b6": contractErrors.ZKPassportIdentifierAlreadyVerified,
+	"0xd13a7934": contractErrors.ZKPassportInvalidScope,
+	"0x69f5bfe7": contractErrors.ZKPassportUnexpectedSender,
+	"0x0464115c": contractErrors.ZKPassportAgeBelowMinimum,
+	"0x48183836": contractErrors.ZKPassportMinAgeTooHigh,
+
+	// Chainlink / oracle
+	"0x7f73f237": contractErrors.UnexpectedRequestId,
+	"0xab948796": contractErrors.OnlyRouterCanFulfill,
+	"0x61982c98": contractErrors.RequestFailed,
+	"0xab66be18": contractErrors.SourceCodeMismatch,
+	"0xff2826ef": contractErrors.ZeroMarketPrice,
+	"0xbb6c216c": contractErrors.InvalidComputedPrices,
+	"0x3a8fbef4": contractErrors.NotPriceUpdaterForCurrency,
+	"0x3e2c36f2": contractErrors.ThresholdNotConfigured,
+	"0x71c4efed": contractErrors.SlippageExceeded,
+
+	// Reputation / verification
+	"0x071ea33c": contractErrors.UserHasNoReputation,
+	"0xd2e1e6e0": contractErrors.ZeroReputationPoints,
+	"0x3c0ca622": contractErrors.NoReputation,
+	"0x412dd2b1": contractErrors.InsufficientRP,
+	"0x0f165e7b": contractErrors.NullifierAlreadyVerified,
+	"0x439cc0cd": contractErrors.VerificationFailed,
+	"0x2366073b": contractErrors.InvalidSocialPlatform,
+	"0x2f850b6b": contractErrors.SocialAlreadyVerified,
+	"0x466f52a8": contractErrors.YearFieldNotInProof,
+	"0x4d460588": contractErrors.UserIdFieldNotInProof,
+	"0xa18ea4e8": contractErrors.UserIdAlreadyVerified,
+	"0x69470b13": contractErrors.UsernameAlreadyVerified,
+	"0x8390b2dd": contractErrors.UsernameNotInProof,
+	"0xef053cf4": contractErrors.LinkedInOnlyRpUpdates,
+	"0x355b0709": contractErrors.FacebookOnlyRpUpdates,
+
+	// Voting / referral
+	"0x7aabdfe3": contractErrors.AlreadyReferred,
+	"0x83463f4a": contractErrors.SelfReferralNotAllowed,
+	"0x69f6994a": contractErrors.NotEligibleToRefer,
+	"0x1b19ad97": contractErrors.MerchantMonthlyReferralLimitReached,
+	"0x944a2241": contractErrors.NoRecommender,
+	"0x0ece93a6": contractErrors.RecommendationAlreadyClaimed,
+	"0x74785d0f": contractErrors.CannotVoteYourself,
+	"0xc26d5f75": contractErrors.VotesPerEpochExceeded,
+	"0x7c9a1cf9": contractErrors.AlreadyVoted,
+	"0x403e7fa6": contractErrors.FunctionNotFound,
+
+	// Campaign
+	"0x7a551e38": contractErrors.CampaignNotActive,
+	"0x668ca75d": contractErrors.InvalidManagerDetails,
+	"0x2f950361": contractErrors.UnclaimedRewardsExist,
+	"0x626b7c00": contractErrors.RewardAlreadyClaimed,
+	"0x902ade67": contractErrors.OnlyNewUsersAllowed,
+	"0x22a5e34b": contractErrors.ManagerNotFound,
+	"0xa1610e37": contractErrors.ManagerInactive,
+	"0x3fb087f4": contractErrors.NoRewards,
+	"0x3eedee0f": contractErrors.InvalidCampaignId,
+	"0x302c5138": contractErrors.CannotClaimRevenueForCurrentMonth,
+
+	// Referral reward config
+	"0x074a6991": contractErrors.RewardPercentageTooHigh,
+
+	// Signature / nonce
+	"0x1fb09b80": contractErrors.NonceAlreadyUsed,
+	"0x2fdec18b": contractErrors.SignatureValidationFailed,
+
+	// Misc
+	"0xe6c4247b": contractErrors.InvalidAddress,
+	"0x3eb17c88": contractErrors.InvalidBlockAmount,
+	"0x2c5211c6": contractErrors.InvalidAmount,
+	"0xb4fa3fb3": contractErrors.InvalidInput,
+	"0x1117a646": contractErrors.InvalidStatusTransition,
+	"0xa24a13a6": contractErrors.ArrayLengthMismatch,
+	"0xebb6f34b": contractErrors.UserIsBlacklisted,
+	"0xd92e233d": contractErrors.ZeroAddress,
+	"0x8beb9d16": contractErrors.ReentrancyGuard,
+	"0xbb1cb70b": contractErrors.BatchTooLarge,
+	"0xd97cf1ba": contractErrors.UnderflowSubtraction,
+	"0xc9b16952": contractErrors.TargetLongerThanData,
+};
+
+/**
+ * Parses an unknown contract revert into a `ContractErrorCode` string.
+ * Inspects hex selectors in `data`, `message`, and nested `cause` fields.
+ * Returns `null` if no known error is matched.
+ */
+export function parseContractError(error: unknown): ContractErrorCode | null {
+	if (!error) return null;
+
+	if (typeof error === "string") {
+		const direct = hexContractErrors[error];
+		if (direct) return direct;
+
+		const hexMatch = error.match(/0x[a-fA-F0-9]{8}/);
+		if (hexMatch) return hexContractErrors[hexMatch[0]] ?? null;
+
+		return null;
+	}
+
+	if (typeof error === "object") {
+		const e = error as {
+			data?: string | { data?: string };
+			message?: string;
+			cause?: unknown;
+		};
+
+		if (e.data) {
+			const hexCode = typeof e.data === "string" ? e.data : e.data.data;
+			if (hexCode) {
+				const match = hexContractErrors[hexCode];
+				if (match) return match;
+			}
+		}
+
+		if (typeof e.message === "string") {
+			const hexMatch = e.message.match(/0x[a-fA-F0-9]{8}/);
+			if (hexMatch) {
+				const match = hexContractErrors[hexMatch[0]];
+				if (match) return match;
+			}
+
+			const jsonMatch = e.message.match(/\{[\s\S]*\}/);
+			if (jsonMatch) {
+				try {
+					const parsed: unknown = JSON.parse(jsonMatch[0]);
+					const embedded = parseContractError(parsed);
+					if (embedded) return embedded;
+				} catch {
+					// not valid JSON
+				}
+			}
+		}
+
+		if (e.cause) return parseContractError(e.cause);
+	}
+
+	return null;
+}

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -1,4 +1,5 @@
 export * from "./abis";
+export * from "./error-messages";
 export * from "./errors";
 export * from "./order-flow";
 export * from "./order-processor";

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -1,4 +1,5 @@
 export * from "./abis";
+export * from "./errors";
 export * from "./order-flow";
 export * from "./order-processor";
 export * from "./p2p-config";

--- a/src/orders/index.ts
+++ b/src/orders/index.ts
@@ -5,6 +5,10 @@ export { createOrders, type OrdersClient } from "./client";
 // ── Errors ──────────────────────────────────────────────────────────────
 
 export {
+	contractErrorMessages,
+	getContractErrorMessage,
+} from "../contracts/error-messages";
+export {
 	type ContractErrorCode,
 	contractErrors,
 	hexContractErrors,

--- a/src/orders/index.ts
+++ b/src/orders/index.ts
@@ -4,6 +4,12 @@ export { createOrders, type OrdersClient } from "./client";
 
 // ── Errors ──────────────────────────────────────────────────────────────
 
+export {
+	type ContractErrorCode,
+	contractErrors,
+	hexContractErrors,
+	parseContractError,
+} from "../contracts/errors";
 export { OrdersError, type OrdersErrorCode } from "./errors";
 
 // ── Domain types ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `src/contracts/errors.ts` mirroring all custom errors from `contracts/libraries/Errors.sol`
- Exports `contractErrors` (named → code map), `hexContractErrors` (4-byte selector → code), `parseContractError()`, and `ContractErrorCode` type
- All three are re-exported on the `@p2pdotme/sdk/orders` public surface

## Usage

```ts
import { parseContractError } from "@p2pdotme/sdk/orders";

const code = parseContractError(err); // e.g. "ORDER_EXPIRED" | "INSUFFICIENT_RP" | null
```

## Test plan

- [ ] `parseContractError` resolves hex selectors from `data`, `message`, and nested `cause` fields
- [ ] `ContractErrorCode` type is exported and usable for type-narrowing
- [ ] Build passes (`bun run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)