### PR TITLE
feat(qr-parsers): add Nigerian QR support (NIBSS NQR + SPD) (#11)

### DIFF
--- a/src/country/currencies/ngn.ts
+++ b/src/country/currencies/ngn.ts
@@ -53,5 +53,5 @@ export const NGN_COUNTRY_OPTION: CountryOption = {
 	precision: 2,
 	isAlpha: true,
 	disabled: false,
-	disabledPaymentTypes: ["PAY"],
+	disabledPaymentTypes: [],
 };

--- a/src/qr-parsers/README.md
+++ b/src/qr-parsers/README.md
@@ -11,6 +11,7 @@ QR code parsers for P2P.me payment networks. Extracts payment addresses and amou
 | BRL      | Brazil      | PIX             | EMVCo TLV + CRC |
 | ARS      | Argentina   | MercadoPago     | EMVCo TLV + CRC |
 | VEN      | Venezuela   | Pago Movil      | Base64 payload  |
+| NGN      | Nigeria     | NQR / NIP       | EMVCo TLV + CRC, SPD |
 
 ## Installation
 

--- a/src/qr-parsers/parse-qr.ts
+++ b/src/qr-parsers/parse-qr.ts
@@ -3,6 +3,7 @@ import { parseMercadoPago } from "./parsers/ars";
 import { parsePIX } from "./parsers/brl";
 import { parseQRIS } from "./parsers/idr";
 import { parseUPI } from "./parsers/inr";
+import { parseNGN } from "./parsers/ngn";
 import { parsePagoMovil } from "./parsers/ven";
 import type { ParseQRParams, ParseResult } from "./types";
 import { failure } from "./types";
@@ -35,6 +36,8 @@ export async function parseQR(params: ParseQRParams): Promise<ParseResult> {
 			return parseMercadoPago(qrData, sellPrice);
 		case CURRENCY.VEN:
 			return parsePagoMovil(qrData, sellPrice);
+		case CURRENCY.NGN:
+			return parseNGN(qrData, sellPrice);
 		default:
 			return failure("INVALID_CURRENCY", `Currency "${currency}" is not supported`);
 	}

--- a/src/qr-parsers/parsers/ngn.ts
+++ b/src/qr-parsers/parsers/ngn.ts
@@ -1,0 +1,110 @@
+import type { ParsedQR, ParseResult } from "../types";
+import { failure, success } from "../types";
+import { parseAmount } from "../utils/amount";
+import { verifyCRC16 } from "../utils/crc16";
+import { extractTags, parseTLV } from "../utils/tlv";
+
+const NGN_TAGS = {
+	AMOUNT: "54",
+	CURRENCY: "53",
+	COUNTRY: "58",
+	MERCHANT_NAME: "59",
+} as const;
+
+const NGN_CURRENCY_CODE = "566";
+const NIBSS_AID = "NG.COM.NIBSSPLC.QR";
+
+function isNQR(qrData: string): boolean {
+	if (qrData.includes(NIBSS_AID)) return true;
+	if (qrData.includes(`5303${NGN_CURRENCY_CODE}`)) return true;
+	if (qrData.includes("5802NG")) return true;
+	return false;
+}
+
+function parseEMVCoNQR(qrData: string, sellPrice: number): ParseResult {
+	const crc = verifyCRC16(qrData);
+	if (!crc.valid) {
+		return failure("INVALID_QR", "Invalid QR checksum");
+	}
+
+	if (!isNQR(qrData)) {
+		return failure("INVALID_QR", "Not a Nigerian (NQR) QR code");
+	}
+
+	const tags = extractTags(qrData, [NGN_TAGS.AMOUNT, NGN_TAGS.MERCHANT_NAME]);
+
+	const merchantName = tags[NGN_TAGS.MERCHANT_NAME];
+	if (!merchantName) {
+		return failure("INVALID_QR", "Missing merchant name");
+	}
+
+	const result: ParsedQR = { paymentAddress: merchantName };
+
+	const amountStr = tags[NGN_TAGS.AMOUNT];
+	if (amountStr) {
+		const amount = parseAmount(amountStr, sellPrice);
+		if (!amount) {
+			return failure("INVALID_AMOUNT", "Invalid amount in QR");
+		}
+		result.amount = amount;
+	}
+
+	return success(result);
+}
+
+function parseSPD(qrData: string, sellPrice: number): ParseResult {
+	// Short Payment Descriptor (Czech spec). Seen in the wild for some
+	// Nigerian account-based QRs: `SPD*1.0*ACC:<nuban>*AM:<amount>*MSG:<text>*`.
+	const parts = qrData.split("*").filter((p) => p.length > 0);
+	if (parts.length < 2 || parts[0] !== "SPD") {
+		return failure("INVALID_QR", "Not a valid SPD QR code");
+	}
+
+	const fields: Record<string, string> = {};
+	for (const part of parts.slice(2)) {
+		const colon = part.indexOf(":");
+		if (colon === -1) continue;
+		fields[part.substring(0, colon).toUpperCase()] = part.substring(colon + 1);
+	}
+
+	const account = fields.ACC;
+	if (!account) {
+		return failure("INVALID_QR", "Missing ACC field in SPD QR");
+	}
+
+	const result: ParsedQR = { paymentAddress: account };
+
+	const amountStr = fields.AM;
+	if (amountStr) {
+		const amount = parseAmount(amountStr.replace(/,/g, ""), sellPrice);
+		if (!amount) {
+			return failure("INVALID_AMOUNT", "Invalid amount in QR");
+		}
+		result.amount = amount;
+	}
+
+	return success(result);
+}
+
+/**
+ * Parses a Nigerian QR code. Supports NIBSS NQR (EMVCo MPM with AID
+ * `NG.COM.NIBSSPLC.QR`) and the SPD `SPD*1.0*ACC:...*AM:...*` format.
+ */
+export function parseNGN(qrData: string, sellPrice: number): ParseResult {
+	if (!qrData || typeof qrData !== "string" || qrData.trim().length === 0) {
+		return failure("INVALID_QR", "QR data is empty or invalid");
+	}
+
+	const trimmed = qrData.trim();
+
+	if (trimmed.startsWith("SPD*")) {
+		return parseSPD(trimmed, sellPrice);
+	}
+
+	// Sanity-check that this looks like EMVCo TLV before CRC-ing.
+	if (parseTLV(trimmed).length === 0) {
+		return failure("INVALID_QR", "Not a valid Nigerian QR code");
+	}
+
+	return parseEMVCoNQR(trimmed, sellPrice);
+}

--- a/test/qr-parsers/ngn.test.ts
+++ b/test/qr-parsers/ngn.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { parseNGN } from "../../src/qr-parsers/parsers/ngn";
+import { calculateCRC16 } from "../../src/qr-parsers/utils/crc16";
+
+function tlv(tag: string, value: string): string {
+	return `${tag}${value.length.toString().padStart(2, "0")}${value}`;
+}
+
+function withCrc(inner: string): string {
+	return `${inner}6304${calculateCRC16(inner)}`;
+}
+
+function unwrap<T, E>(r: { isOk(): boolean; isErr(): boolean; value?: T; error?: E }) {
+	if (r.isErr()) throw new Error(`expected ok, got err: ${String(r.error)}`);
+	return r.value as T;
+}
+
+describe("parseNGN — NIBSS NQR (EMVCo)", () => {
+	it("parses a static NQR with merchant name, no amount", () => {
+		const merchantInfo = `${tlv("00", "NG.COM.NIBSSPLC.QR")}${tlv("01", "S000000000000")}`;
+		const inner =
+			`${tlv("00", "01")}${tlv("01", "11")}${tlv("26", merchantInfo)}` +
+			`${tlv("52", "0000")}${tlv("53", "566")}${tlv("58", "NG")}` +
+			`${tlv("59", "ACME STORE NG")}${tlv("60", "Lagos")}`;
+		const data = unwrap(parseNGN(withCrc(inner), 1500));
+		expect(data.paymentAddress).toBe("ACME STORE NG");
+		expect(data.amount).toBeUndefined();
+	});
+
+	it("parses a dynamic NQR with amount", () => {
+		const merchantInfo = `${tlv("00", "NG.COM.NIBSSPLC.QR")}${tlv("01", "S000000000000")}`;
+		const inner =
+			`${tlv("00", "01")}${tlv("01", "12")}${tlv("26", merchantInfo)}` +
+			`${tlv("52", "0000")}${tlv("53", "566")}${tlv("54", "15000.00")}` +
+			`${tlv("58", "NG")}${tlv("59", "MERCHANT ONE")}${tlv("60", "Lagos")}`;
+		const data = unwrap(parseNGN(withCrc(inner), 1500));
+		expect(data.paymentAddress).toBe("MERCHANT ONE");
+		expect(data.amount).toEqual({ usdc: 10, fiat: 15000 });
+	});
+
+	it("accepts NQR with only country=NG marker (no explicit currency tag)", () => {
+		const inner =
+			`${tlv("00", "01")}${tlv("01", "11")}${tlv("58", "NG")}${tlv("59", "SHOP NG")}`;
+		const data = unwrap(parseNGN(withCrc(inner), 1500));
+		expect(data.paymentAddress).toBe("SHOP NG");
+	});
+
+	it("returns INVALID_QR on CRC mismatch", () => {
+		const inner = `${tlv("00", "01")}${tlv("53", "566")}${tlv("58", "NG")}${tlv("59", "M")}`;
+		const result = parseNGN(`${inner}6304FFFF`, 1500);
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) expect(result.error.code).toBe("INVALID_QR");
+	});
+
+	it("returns INVALID_QR when no Nigerian marker is present", () => {
+		const inner = `${tlv("00", "01")}${tlv("53", "840")}${tlv("58", "US")}${tlv("59", "SHOP")}`;
+		const result = parseNGN(withCrc(inner), 1500);
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) expect(result.error.code).toBe("INVALID_QR");
+	});
+
+	it("returns INVALID_QR when merchant name is missing", () => {
+		const inner = `${tlv("00", "01")}${tlv("53", "566")}${tlv("58", "NG")}`;
+		const result = parseNGN(withCrc(inner), 1500);
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) expect(result.error.code).toBe("INVALID_QR");
+	});
+
+	it("returns INVALID_AMOUNT on unparseable amount", () => {
+		const inner =
+			`${tlv("00", "01")}${tlv("53", "566")}${tlv("54", "abc")}` +
+			`${tlv("58", "NG")}${tlv("59", "SHOP")}`;
+		const result = parseNGN(withCrc(inner), 1500);
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) expect(result.error.code).toBe("INVALID_AMOUNT");
+	});
+});
+
+describe("parseNGN — SPD format (Access Bank Nigeria)", () => {
+	it("parses an SPD QR with account, amount and message", () => {
+		const data = unwrap(parseNGN("SPD*1.0*ACC:1234567890*AM:40,000.00*MSG:Test*", 1500));
+		expect(data.paymentAddress).toBe("1234567890");
+		expect(data.amount).toEqual({ usdc: 40000 / 1500, fiat: 40000 });
+	});
+
+	it("parses an SPD QR with only account", () => {
+		const data = unwrap(parseNGN("SPD*1.0*ACC:1234567890*", 1500));
+		expect(data.paymentAddress).toBe("1234567890");
+		expect(data.amount).toBeUndefined();
+	});
+
+	it("returns INVALID_QR when ACC field is missing", () => {
+		const result = parseNGN("SPD*1.0*AM:1000*", 1500);
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) expect(result.error.code).toBe("INVALID_QR");
+	});
+
+	it("returns INVALID_AMOUNT on unparseable amount", () => {
+		const result = parseNGN("SPD*1.0*ACC:1234567890*AM:notanumber*", 1500);
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) expect(result.error.code).toBe("INVALID_AMOUNT");
+	});
+});
+
+describe("parseNGN — input validation", () => {
+	it.each([
+		["empty", ""],
+		["whitespace", "   "],
+	])("returns INVALID_QR for %s", (_label, input) => {
+		const result = parseNGN(input, 1500);
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) expect(result.error.code).toBe("INVALID_QR");
+	});
+
+	it("returns INVALID_QR for non-TLV, non-SPD data", () => {
+		const result = parseNGN("hello world", 1500);
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) expect(result.error.code).toBe("INVALID_QR");
+	});
+});


### PR DESCRIPTION
Adds parseNGN covering two formats seen in the wild:
- EMVCo MPM with NIBSS AID NG.COM.NIBSSPLC.QR (currency 566, country NG)
- SPD*1.0*ACC:<nuban>*AM:<amount>*MSG:<text>* (Access Bank Nigeria)

Wires NGN into the parseQR dispatcher and flips NGN's disabledPaymentTypes so PAY orders are no longer blocked for Nigeria.