### PR TITLE
feat(country/ven): rename RIF field to Cédula (V), V-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p2pdotme/sdk",
-  "version": "1.2.0",
+  "version": "1.1.2",
   "description": "P2P.me SDK",
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p2pdotme/sdk",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "P2P.me SDK",
   "license": "MIT",
   "type": "module",

--- a/src/country/README.md
+++ b/src/country/README.md
@@ -82,7 +82,7 @@ validatePIXId("user@example.com"); // true
 | `validateArgentinePaymentId` | ARS | CBU/CVU (22 digits with checksum) or Alias (6–20 chars) |
 | `validateMexicanPaymentId` | MEX | CLABE (18 digits), card (16 digits), phone (10 digits) |
 | `validateVenezuelanPhoneNumber` | VEN | 11-digit number starting with `04` |
-| `validateVenezuelanRif` | VEN | Letter prefix (J/V/E/G/C) + 7–9 digits |
+| `validateVenezuelanRif` | VEN | `V` prefix + digits (Cédula, natural persons only) |
 | `validateNigerianAccountNumber` | NGN | Exactly 10 digits (NUBAN) |
 | `validateColombianPaymentId` | COP | 10-digit phone starting with `3`, or email |
 | `validateRevolutId` | EUR/USD | Username, email, or phone |

--- a/src/country/currencies/ven.ts
+++ b/src/country/currencies/ven.ts
@@ -48,7 +48,7 @@ export const VEN_PAYMENT_FIELDS: PaymentIdFieldConfig[] = [
 		key: "rif",
 		label: "RIF_LABEL",
 		placeholder: VEN_PLACEHOLDER_RIF,
-		displayLabel: "Cédula (V)",
+		displayLabel: "Cedula con V",
 		validate: validateVenezuelanRif,
 		validationErrorMessage: VEN_VALIDATION_ERROR_RIF,
 	},

--- a/src/country/currencies/ven.ts
+++ b/src/country/currencies/ven.ts
@@ -48,7 +48,7 @@ export const VEN_PAYMENT_FIELDS: PaymentIdFieldConfig[] = [
 		key: "rif",
 		label: "RIF_LABEL",
 		placeholder: VEN_PLACEHOLDER_RIF,
-		displayLabel: "Cédula",
+		displayLabel: "Cédula (V)",
 		validate: validateVenezuelanRif,
 		validationErrorMessage: VEN_VALIDATION_ERROR_RIF,
 	},

--- a/src/country/currencies/ven.ts
+++ b/src/country/currencies/ven.ts
@@ -6,7 +6,7 @@ export const VEN_PLACEHOLDER_RIF = "V12345678";
 export const VEN_PLACEHOLDER_BANK = "Banesco";
 
 export const VEN_VALIDATION_ERROR = "Please enter a valid phone number (e.g., 04121234567)";
-export const VEN_VALIDATION_ERROR_RIF = "Please enter a valid RIF (e.g., V12345678)";
+export const VEN_VALIDATION_ERROR_RIF = "Please enter a valid Cédula (e.g., V12345678)";
 export const VEN_VALIDATION_ERROR_BANK = "Please enter a bank name";
 
 /**
@@ -25,13 +25,13 @@ export function validateVenezuelanPhoneNumber(phoneNumber: string): boolean {
 }
 
 /**
- * Validates Venezuelan RIF (Registro de Informacion Fiscal).
- * Format: One letter (J/V/E/G/C) followed by 7-9 digits.
+ * Validates Venezuelan Cédula. Format: "V" followed by digits.
+ * Only natural-person cédulas (V) are accepted; legal-entity RIFs are not.
  */
 export function validateVenezuelanRif(rif: string): boolean {
 	if (!rif || rif.trim().length === 0) return false;
 	const trimmed = rif.trim().toUpperCase();
-	return /^[JVEGC]\d{7,9}$/.test(trimmed);
+	return /^V\d+$/.test(trimmed);
 }
 
 /** Payment ID field configuration for VEN (Venezuela, Pago Móvil). */
@@ -48,7 +48,7 @@ export const VEN_PAYMENT_FIELDS: PaymentIdFieldConfig[] = [
 		key: "rif",
 		label: "RIF_LABEL",
 		placeholder: VEN_PLACEHOLDER_RIF,
-		displayLabel: "RIF",
+		displayLabel: "Cédula",
 		validate: validateVenezuelanRif,
 		validationErrorMessage: VEN_VALIDATION_ERROR_RIF,
 	},

--- a/test/country/validators.test.ts
+++ b/test/country/validators.test.ts
@@ -197,11 +197,9 @@ describe("validateVenezuelanPhoneNumber (VEN)", () => {
 describe("validateVenezuelanRif (VEN)", () => {
 	it.each([
 		["V prefix (individual)", "V12345678"],
-		["J prefix (company)", "J123456789"],
-		["E prefix (foreigner)", "E1234567"],
-		["G prefix (government)", "G12345678"],
-		["C prefix (communal council)", "C12345678"],
 		["lowercase prefix (normalized)", "v12345678"],
+		["short suffix (legacy)", "V12345"],
+		["long suffix", "V1234567890"],
 		["9-digit suffix", "V123456789"],
 	])("accepts %s", (_label, input) => {
 		expect(validateVenezuelanRif(input)).toBe(true);
@@ -210,9 +208,11 @@ describe("validateVenezuelanRif (VEN)", () => {
 	it.each([
 		["empty string", ""],
 		["whitespace only", "   "],
+		["J prefix (company, no longer allowed)", "J123456789"],
+		["E prefix (foreigner, no longer allowed)", "E1234567"],
+		["G prefix (government, no longer allowed)", "G12345678"],
+		["C prefix (communal council, no longer allowed)", "C12345678"],
 		["invalid prefix", "X12345678"],
-		["suffix too short (6 digits)", "V123456"],
-		["suffix too long (10 digits)", "V1234567890"],
 		["letters in suffix", "V1234abcd"],
 		["no prefix", "12345678"],
 	])("rejects %s", (_label, input) => {


### PR DESCRIPTION
## Summary
- Rename Venezuela's payment field display label from \`RIF\` to \`Cédula (V)\` — feedback from VE users that "RIF" is confusing; in practice they enter their personal cédula.
- Tighten \`validateVenezuelanRif\` to \`^V\d+$\` (V prefix, any digit length). Drops J/E/G/C prefixes (legal-entity RIFs no longer accepted) but keeps short legacy cédula numbers valid.
- Update validation error message to "Please enter a valid Cédula (e.g., V12345678)".
- Tests + README updated.

## Migration impact
- **Stored data unchanged.** Compound payment IDs persisted as \`phone|V…\` strings remain valid — no DB migration needed.
- **Field key (\`"rif"\`) and i18n key (\`RIF_LABEL\`) preserved** to keep the diff minimal in consumer apps.
- **Existing merchants on V prefix:** ✅ unaffected.
- **Existing merchants on J/E/G/C prefix:** ⚠️ will need to re-enter a V-prefixed cédula on next edit. Per product decision: only natural-person cédulas are supported in VE.

## Test plan
- [x] \`bun run test\` — \`validateVenezuelanRif\` cases updated and passing
- [ ] Verify in merchant-app + user-app PRs that the new label renders correctly across all 5 locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)