### PR TITLE
feat(country): add Bre-B @alias support for Colombian payment ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p2pdotme/sdk",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "P2P.me SDK",
   "license": "MIT",
   "type": "module",

--- a/src/country/currencies/cop.ts
+++ b/src/country/currencies/cop.ts
@@ -1,19 +1,21 @@
 import { CURRENCY } from "../currency";
 import type { CountryOption, PaymentIdFieldConfig } from "../types";
 
-export const COP_PLACEHOLDER = "juan.perez@nequi.com.co";
+export const COP_PLACEHOLDER = "3001234567 / juan.perez@nequi.com.co / @alias";
 export const COP_VALIDATION_ERROR =
-	"Please enter a valid Nequi or Daviplata ID (e.g., 3001234567 or email)";
+	"Please enter a valid Colombian payment ID (e.g., 3001234567, email, or @alias)";
 
 /**
- * Validates Colombian payment ID for Nequi or Daviplata.
- * Accepts a 10-digit phone number starting with 3, or a valid email address.
+ * Validates Colombian payment ID for Nequi, Daviplata, or Bre-B.
+ * Accepts a 10-digit phone number starting with 3, a valid email address,
+ * or a Bre-B alias starting with @ (e.g. @juanperez).
  */
 export function validateColombianPaymentId(paymentId: string): boolean {
 	if (!paymentId || paymentId.trim().length === 0) return false;
 	const trimmed = paymentId.trim();
 	if (/^3\d{9}$/.test(trimmed)) return true;
 	if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) return true;
+	if (/^@\S+$/.test(trimmed)) return true;
 	return false;
 }
 
@@ -23,7 +25,7 @@ export const COP_PAYMENT_FIELDS: PaymentIdFieldConfig[] = [
 		key: "alias",
 		label: "ALIAS_TRANSFERENCIA",
 		placeholder: COP_PLACEHOLDER,
-		displayLabel: "Nequi / Daviplata",
+		displayLabel: "Nequi / Daviplata / Bre-B",
 		validate: validateColombianPaymentId,
 		validationErrorMessage: COP_VALIDATION_ERROR,
 	},

--- a/test/country/validators.test.ts
+++ b/test/country/validators.test.ts
@@ -250,6 +250,11 @@ describe("validateColombianPaymentId (COP)", () => {
 		["Daviplata phone", "3241234567"],
 		["email address", "juan.perez@nequi.com.co"],
 		["simple email", "user@example.com"],
+		["Bre-B alias", "@juanperez"],
+		["Bre-B alias with dots", "@juan.perez"],
+		["Bre-B alias with underscores", "@juan_perez"],
+		["Bre-B alias with hyphens", "@juan-perez"],
+		["Bre-B alias with numbers", "@juan123"],
 	])("accepts %s", (_label, input) => {
 		expect(validateColombianPaymentId(input)).toBe(true);
 	});
@@ -262,6 +267,8 @@ describe("validateColombianPaymentId (COP)", () => {
 		["phone starting with 3 but 11 digits", "30012345678"],
 		["invalid email (no @)", "juannequi.com"],
 		["invalid email (no domain)", "juan@"],
+		["@ sign alone", "@"],
+		["@ with spaces", "@ juanperez"],
 	])("rejects %s", (_label, input) => {
 		expect(validateColombianPaymentId(input)).toBe(false);
 	});


### PR DESCRIPTION
## Summary
- Adds support for Bre-B `@alias` keys in the Colombian payment ID validator
- Accepts three formats: 10-digit phone (`3001234567`), email, or `@alias`
- Updates placeholder, validation error message, and display label to reflect all supported formats

## Test plan
- [x] Unit tests added for `@alias` acceptance (with dots, underscores, hyphens, numbers)
- [x] Unit tests added for invalid `@` cases (bare `@`, `@` with spaces)
- [x] All 326 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)