### PR TITLE
Add localStorage device hash signal to fraud-engine client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p2pdotme/sdk",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "P2P.me SDK",
   "license": "MIT",
   "type": "module",

--- a/src/fraud-engine/client.ts
+++ b/src/fraud-engine/client.ts
@@ -1,6 +1,7 @@
 import { errAsync, ResultAsync } from "neverthrow";
 import { type Logger, noopLogger } from "../lib";
 import { getDeviceDetails } from "./device";
+import { getOrCreateDeviceHash } from "./device-hash";
 import { encryptPayload } from "./encryption";
 import { FraudEngineError } from "./errors";
 import { getFingerprint as getFingerprintResult, loadFingerprintAgent } from "./fingerprint";
@@ -285,6 +286,8 @@ export function createFraudEngine(config: FraudEngineConfig): FraudEngine {
 						return null;
 					}
 
+					const localstorageHash = getOrCreateDeviceHash();
+
 					const signedHeaders = await getSignedHeaders(params.signer, "fingerprint-log");
 
 					const normalizedAddress = params.signer.address.toLowerCase();
@@ -292,6 +295,7 @@ export function createFraudEngine(config: FraudEngineConfig): FraudEngine {
 
 					const payload = JSON.stringify({
 						fingerprint_id: fingerprintResult.visitorId,
+						localstorage_hash: localstorageHash,
 					});
 
 					// AAD format: "fingerprint|user_address|timestamp"

--- a/src/fraud-engine/device-hash.ts
+++ b/src/fraud-engine/device-hash.ts
@@ -1,0 +1,29 @@
+const STORAGE_KEY = "@P2PME:DEVICE_HASH";
+
+const UUID_RE = /^[0-9a-f-]{36}$/;
+
+let cached: string | null = null;
+
+/**
+ * Returns a stable per-localStorage identifier, creating one on first call.
+ * Returns null when localStorage or crypto is unavailable.
+ */
+export function getOrCreateDeviceHash(): string | null {
+	if (cached) return cached;
+	if (typeof localStorage === "undefined" || typeof crypto === "undefined") {
+		return null;
+	}
+	try {
+		const existing = localStorage.getItem(STORAGE_KEY);
+		if (existing && UUID_RE.test(existing)) {
+			cached = existing;
+			return existing;
+		}
+		const fresh = crypto.randomUUID();
+		localStorage.setItem(STORAGE_KEY, fresh);
+		cached = fresh;
+		return fresh;
+	} catch {
+		return null;
+	}
+}

--- a/src/fraud-engine/index.ts
+++ b/src/fraud-engine/index.ts
@@ -30,6 +30,7 @@ export { FraudEngineError, type FraudEngineErrorCode } from "./errors";
 // ── Low-level exports (for advanced use) ────────────────────────────────
 
 export { fetchIpAddress, getBasicDeviceDetails, getDeviceDetails } from "./device";
+export { getOrCreateDeviceHash } from "./device-hash";
 export { encryptPayload } from "./encryption";
 export { getFingerprint, loadFingerprintAgent } from "./fingerprint";
 export { cleanupSeonStorage, getSeonSession, initSeon } from "./seon";


### PR DESCRIPTION
## Summary
- Adds a client-generated UUID stored in `localStorage` (`@P2PME:DEVICE_HASH`) and sends it alongside the FingerprintJS `visitor_id` in the encrypted `logFingerprint` payload.
- Lets the fraud-engine backend require both signals to match before treating two wallets as the same device — eliminates false positives from FingerprintJS visitor_id collisions between unrelated users on similar device configs.
- Bumped to `1.2.0` (additive, backwards compatible — backend tolerates a `null` hash and simply does not auto-blacklist any cluster connected through such a row).

## Changes
- `src/fraud-engine/device-hash.ts` (new): `getOrCreateDeviceHash()` reads/creates a UUID at `@P2PME:DEVICE_HASH`, caches it in module scope, and returns `null` in private-mode / SSR / quota-exceeded scenarios.
- `src/fraud-engine/client.ts`: `logFingerprint` now sends `{fingerprint_id, localstorage_hash}` instead of `{fingerprint_id}`.
- `src/fraud-engine/index.ts`: re-exports `getOrCreateDeviceHash` for parity with `getFingerprint`.
- Survives logout — `cleanupSeonStorage` only touches `seon_session_sent_*` keys, so the device-hash key is intentionally left intact (clearing it on logout would defeat the gate).

## Companion
- Backend side: p2pdotme/fraud-engine PR (feat/fingerprint-localstorage-hash) consumes and validates the new field.
- user-app-spa will be bumped to `@p2pdotme/sdk@1.2.0` in a separate PR.

## Test plan
- [ ] `bun run typecheck` and `bun run build` pass locally.
- [ ] Open consuming app in fresh browser profile; verify `@P2PME:DEVICE_HASH` appears in `localStorage` as a UUID after login.
- [ ] Confirm encrypted `POST /fingerprint-log` payload contains `localstorage_hash` (decrypt manually or instrument the SDK).
- [ ] Clear `localStorage`; reload — confirm a fresh UUID is generated and persisted.
- [ ] Open in private mode; confirm `getOrCreateDeviceHash()` returns `null` and the request still succeeds.
- [ ] Verify `cleanupSeonStorage()` (called on logout) does **not** clear the device-hash key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)