### PR TITLE
feat(qr-parsers): Colombian QR support (DIAN, Nequi, Bre-B)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p2pdotme/sdk",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "P2P.me SDK",
   "license": "MIT",
   "type": "module",

--- a/src/country/currencies/cop.ts
+++ b/src/country/currencies/cop.ts
@@ -50,5 +50,5 @@ export const COP_COUNTRY_OPTION: CountryOption = {
 	precision: 2,
 	isAlpha: true,
 	disabled: false,
-	disabledPaymentTypes: ["PAY"],
+	disabledPaymentTypes: [],
 };

--- a/src/qr-parsers/parse-qr.ts
+++ b/src/qr-parsers/parse-qr.ts
@@ -1,6 +1,7 @@
 import { CURRENCY } from "../country";
 import { parseMercadoPago } from "./parsers/ars";
 import { parsePIX } from "./parsers/brl";
+import { parseCOP } from "./parsers/cop";
 import { parseQRIS } from "./parsers/idr";
 import { parseUPI } from "./parsers/inr";
 import { parseNGN } from "./parsers/ngn";
@@ -38,6 +39,8 @@ export async function parseQR(params: ParseQRParams): Promise<ParseResult> {
 			return parsePagoMovil(qrData, sellPrice);
 		case CURRENCY.NGN:
 			return parseNGN(qrData, sellPrice);
+		case CURRENCY.COP:
+			return parseCOP(qrData, sellPrice);
 		default:
 			return failure("INVALID_CURRENCY", `Currency "${currency}" is not supported`);
 	}

--- a/src/qr-parsers/parsers/cop.ts
+++ b/src/qr-parsers/parsers/cop.ts
@@ -1,0 +1,77 @@
+import type { ParsedQR, ParseResult } from "../types";
+import { failure, success } from "../types";
+import { parseAmount } from "../utils/amount";
+import { extractTags } from "../utils/tlv";
+
+const COP_CURRENCY_CODE = "5303170";
+const CO_COUNTRY_CODE = "5802CO";
+
+const DIAN_KEYS = ["NumFac", "CUFE", "Cufe", "NitFac", "ValFac", "ValTolFac"] as const;
+
+function parseDianInvoice(qrData: string): ParseResult | null {
+	const hasDianMarker = DIAN_KEYS.some(
+		(k) => qrData.includes(`${k}:`) || qrData.includes(`${k} :`),
+	);
+	if (!hasDianMarker) return null;
+
+	const fields: Record<string, string> = {};
+	const segments = qrData.split(/[\n,;]+/);
+	for (const segment of segments) {
+		const idx = segment.indexOf(":");
+		if (idx === -1) continue;
+		const key = segment.substring(0, idx).trim();
+		const value = segment.substring(idx + 1).trim();
+		if (key && value && !fields[key]) fields[key] = value;
+	}
+
+	const cufe = fields.CUFE || fields.Cufe || fields.cufe;
+	const numFac = fields.NumFac;
+	const paymentAddress = cufe || numFac;
+
+	if (!paymentAddress) {
+		return failure("INVALID_QR", "Missing CUFE / NumFac in DIAN invoice QR");
+	}
+
+	return success({ paymentAddress });
+}
+
+function parseColombianEMV(qrData: string, sellPrice: number): ParseResult | null {
+	const isCO = qrData.includes(CO_COUNTRY_CODE);
+	const isCOP = qrData.includes(COP_CURRENCY_CODE);
+	if (!isCO || !isCOP) return null;
+
+	const tags = extractTags(qrData, ["54", "59"]);
+	const merchantName = tags["59"] || "MERCHANT_NOT_FOUND";
+
+	const result: ParsedQR = { paymentAddress: merchantName };
+
+	const amountStr = tags["54"];
+	if (amountStr) {
+		const amount = parseAmount(amountStr, sellPrice);
+		if (amount) result.amount = amount;
+	}
+
+	return success(result);
+}
+
+/**
+ * Parses a Colombian QR. Supports DIAN electronic invoice QRs
+ * (key:value text with `CUFE`/`NumFac`) and EMVCo-encoded QRs from
+ * Colombian payment networks (Nequi, Bre-B/RBM) identified by country
+ * `5802CO` and currency `5303170`.
+ */
+export function parseCOP(qrData: string, sellPrice: number): ParseResult {
+	if (!qrData || typeof qrData !== "string" || qrData.trim().length === 0) {
+		return failure("INVALID_QR", "QR data is empty or invalid");
+	}
+
+	const trimmed = qrData.trim();
+
+	const dian = parseDianInvoice(trimmed);
+	if (dian) return dian;
+
+	const emv = parseColombianEMV(trimmed, sellPrice);
+	if (emv) return emv;
+
+	return failure("INVALID_QR", "Not a recognized Colombian QR code");
+}

--- a/test/qr-parsers/cop.test.ts
+++ b/test/qr-parsers/cop.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { parseCOP } from "../../src/qr-parsers/parsers/cop";
+
+function unwrap<T, E>(r: { isOk(): boolean; isErr(): boolean; value?: T; error?: E }) {
+	if (r.isErr()) throw new Error(`expected ok, got err: ${String(r.error)}`);
+	return r.value as T;
+}
+
+// Synthetic fixtures only — shapes mirror real DIAN / Nequi / Bre-B QRs but
+// every identifier (CUFE, NIT, DocAdq, merchant name, account number) is made
+// up. Do NOT paste real-world QRs here, they contain PII.
+
+function tlv(tag: string, value: string): string {
+	return `${tag}${value.length.toString().padStart(2, "0")}${value}`;
+}
+
+// Minimal valid Colombian EMVCo TLV: country 5802CO + currency 5303170 +
+// merchant name. parseCOP only checks for the CO country / COP currency
+// markers and extracts tag 59 — the rest is just structurally valid filler.
+function buildCopEmv(merchantName: string, extraTemplates = ""): string {
+	const inner =
+		`${tlv("00", "01")}` +
+		`${tlv("01", "11")}` +
+		extraTemplates +
+		`${tlv("52", "0000")}` +
+		`${tlv("53", "170")}` +
+		`${tlv("58", "CO")}` +
+		`${tlv("59", merchantName)}`;
+	return `${inner}6304ABCD`;
+}
+
+describe("parseCOP — DIAN electronic invoice (newline format)", () => {
+	const FAKE_CUFE = "0".repeat(96);
+	const QR = `NumFac: TEST00000001
+FecFac: 2024-01-01
+HorFac: 00:00:00-05:00
+NitFac: 900000000
+DocAdq: 1000000000
+ValFac: 100.00
+ValIva: 19.00
+ValOtroIm: 0.00
+ValTolFac: 119.00
+CUFE: ${FAKE_CUFE}
+https://catalogo-vpfe.dian.gov.co/document/searchqr?documentkey=${FAKE_CUFE}`;
+
+	it("returns CUFE as paymentAddress", () => {
+		const data = unwrap(parseCOP(QR, 4000));
+		expect(data.paymentAddress).toBe(FAKE_CUFE);
+	});
+});
+
+describe("parseCOP — DIAN compact (comma-separated, lowercase Cufe)", () => {
+	const FAKE_CUFE = "a".repeat(40);
+	const QR = `NumFac: TEST00000002,FecFac:20240101000000,NitFac:900000001,DocAdq:1000000001,ValFac:0.00;ValIVA:0.00,ValOtrImp:0.00,ValFacImp:0.00,Cufe:${FAKE_CUFE}`;
+
+	it("returns Cufe as paymentAddress", () => {
+		const data = unwrap(parseCOP(QR, 4000));
+		expect(data.paymentAddress).toBe(FAKE_CUFE);
+	});
+});
+
+describe("parseCOP — Nequi-shaped EMVCo QR", () => {
+	const QR = buildCopEmv("TEST MERCHANT", tlv("92", `${tlv("00", "co.com.nequi")}${tlv("01", "P2P.NEQUI")}`));
+
+	it("extracts merchant name from tag 59", () => {
+		const data = unwrap(parseCOP(QR, 4000));
+		expect(data.paymentAddress).toBe("TEST MERCHANT");
+		expect(data.amount).toBeUndefined();
+	});
+});
+
+describe("parseCOP — Bre-B-shaped EMVCo QR", () => {
+	const QR = buildCopEmv(
+		"testshop",
+		tlv("26", `${tlv("00", "CO.COM.RBM.LLA")}${tlv("05", "0000000000")}`),
+	);
+
+	it("extracts merchant name from tag 59", () => {
+		const data = unwrap(parseCOP(QR, 4000));
+		expect(data.paymentAddress).toBe("testshop");
+	});
+});
+
+describe("parseCOP — invalid inputs", () => {
+	it.each([
+		["empty", ""],
+		["whitespace", "   "],
+	])("returns INVALID_QR for %s", (_label, input) => {
+		const result = parseCOP(input, 4000);
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) expect(result.error.code).toBe("INVALID_QR");
+	});
+
+	it("returns INVALID_QR for unrecognized payload", () => {
+		const result = parseCOP("just some random text", 4000);
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) expect(result.error.code).toBe("INVALID_QR");
+	});
+});


### PR DESCRIPTION
## Summary
- New `parseCOP` parser supporting DIAN electronic invoice receipts (newline + comma formats) and EMVCo payloads from Nequi and Bre-B/RBM (country `5802CO` + currency `5303170`)
- Wired into the `parseQR` dispatcher as `case CURRENCY.COP`
- Enables PAY for Colombia (`disabledPaymentTypes: []` on the COP country option)
- Bumps to `1.1.4`
