### PR TITLE
chore(deps): widen @zkpassport/sdk peer range to allow 0.14.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
   "peerDependencies": {
     "react": "18 || ^19",
     "@reclaimprotocol/js-sdk": "^4",
-    "@zkpassport/sdk": "^0.12.4"
+    "@zkpassport/sdk": ">=0.12.4 <0.15.0"
   },
   "peerDependenciesMeta": {
     "@reclaimprotocol/js-sdk": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p2pdotme/sdk",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "P2P.me SDK",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- Widen the `@zkpassport/sdk` peer dependency from `^0.12.4` to `>=0.12.4 <0.15.0`.
- Caret on a 0.x version only allows patch bumps, so the previous range did **not** satisfy 0.14.0 and would produce peer warnings (or hard failures under strict peer resolution) for consumers like `user-app-client`.
- ZKPassport team is rolling out a breaking app release on **Thursday 2026-05-14 at 10:00 UTC** that requires consumers to upgrade to `@zkpassport/sdk@0.14.0`. See companion PR: p2pdotme/user-app-client#20.

## Why no code changes
- `src/zkkyc/orchestrators/zk-passport.ts` integrates via a dynamic `any`-typed import (`await import("@zkpassport/sdk")`), so the TypeScript surface is not pinned to 0.12.x.
- The runtime API used (`new ZKPassport(domain)`, `.request(...)`, `.gte/.disclose/.bind/.done()`, `getSolidityVerifierParameters({proof, scope, devMode})`) should continue to work against 0.14.x; the user-app smoke test below is the source of truth.

## Test plan
- [ ] `bun install` clean against `@zkpassport/sdk@0.14.0`
- [ ] `bun run build` / typecheck clean
- [ ] End-to-end smoke test of the ZK Passport personhood flow from `user-app-client` against the new app build (passport + ID card paths)
- [ ] If the 0.14.x runtime API has shifted, follow up with code changes in `zk-passport.ts`