### PR TITLE
chore: update mx/co telegram channels and bump to 1.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p2pdotme/sdk",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "P2P.me SDK",
   "license": "MIT",
   "type": "module",

--- a/src/country/currencies/cop.ts
+++ b/src/country/currencies/cop.ts
@@ -44,7 +44,7 @@ export const COP_COUNTRY_OPTION: CountryOption = {
 	flag: "🇨🇴",
 	flagUrl: "https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f1e8-1f1f4.png",
 	phoneCode: "+57",
-	telegramSupportChannel: "https://t.me/p2pmeColombia",
+	telegramSupportChannel: "https://t.me/p2pmecolombiaclientes",
 	twitterUsername: "p2pmeColombia",
 	smsCountryCodes: ["CO"],
 	precision: 2,

--- a/src/country/currencies/mex.ts
+++ b/src/country/currencies/mex.ts
@@ -47,7 +47,7 @@ export const MEX_COUNTRY_OPTION: CountryOption = {
 	flag: "🇲🇽",
 	flagUrl: "https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f1f2-1f1fd.png",
 	phoneCode: "+52",
-	telegramSupportChannel: "https://t.me/p2pmemexico",
+	telegramSupportChannel: "https://t.me/p2pdotmex",
 	twitterUsername: "p2pmemexico",
 	smsCountryCodes: ["MX"],
 	precision: 2,


### PR DESCRIPTION
## Summary
- Update Mexico telegram channel to `t.me/p2pdotmex`
- Update Colombia telegram channel to `t.me/p2pmecolombiaclientes`
- Bump SDK version to 1.1.7

## Test plan
- [ ] Verify both telegram links open correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)