### PR TITLE
fix: capacity-aware routing weight and bootstrap reserve

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p2pdotme/sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "P2P.me SDK",
   "license": "MIT",
   "type": "module",

--- a/src/orders/internal/routing/routing.ts
+++ b/src/orders/internal/routing/routing.ts
@@ -6,9 +6,15 @@ import type { CircleForRouting, Logger } from "./types";
 const EPSILON = 0.25;
 const RECOVERY_SCALE = 0.3;
 const BOOTSTRAP_MAX_WEIGHT = 25;
+const BOOTSTRAP_RESERVE = 0.1;
 const MAX_VALIDATION_ATTEMPTS = 3;
 
-export function circleWeight(c: CircleForRouting): number {
+/**
+ * Status-adjusted score for a circle, before applying capacity.
+ * Active: raw score. Bootstrap: capped at BOOTSTRAP_MAX_WEIGHT.
+ * Paused: scaled by RECOVERY_SCALE.
+ */
+function baseScore(c: CircleForRouting): number {
 	const score = c.metrics.circleScore;
 	if (c.metrics.circleStatus === "paused") {
 		return score * RECOVERY_SCALE;
@@ -19,11 +25,30 @@ export function circleWeight(c: CircleForRouting): number {
 	return score;
 }
 
+/**
+ * Routing weight = base(score, status) × availableMerchantsCount.
+ * Linear capacity is equivalent to weighting each merchant by their circle's
+ * score, so per-merchant load ratio equals the score ratio — bounded by
+ * quality, not by structural pool-size disparity.
+ */
+export function circleWeight(c: CircleForRouting): number {
+	return baseScore(c) * c.metrics.scoreState.availableMerchantsCount;
+}
+
+/**
+ * Filter circles eligible for routing: currency match (case-insensitive) and
+ * at least one available merchant. Skipping zero-capacity circles up front
+ * saves on-chain eligibility-check retries.
+ */
 export function filterEligibleCircles(
 	circles: readonly CircleForRouting[],
 	orderCurrency: string,
 ): CircleForRouting[] {
-	return circles.filter((c) => c.currency.toLowerCase() === orderCurrency.toLowerCase());
+	return circles.filter(
+		(c) =>
+			c.currency.toLowerCase() === orderCurrency.toLowerCase() &&
+			c.metrics.scoreState.availableMerchantsCount > 0,
+	);
 }
 
 function weightedRandomChoice<T>(arr: readonly T[], weights: readonly number[]): T {
@@ -43,29 +68,50 @@ function weightedRandomChoice<T>(arr: readonly T[], weights: readonly number[]):
 	return arr[arr.length - 1];
 }
 
+/**
+ * Select a circle from the eligible pool.
+ *
+ * Resolution order:
+ *   1. ~BOOTSTRAP_RESERVE share goes only to bootstrap circles (when present),
+ *      so new circles can accumulate the order history they need to graduate.
+ *   2. ε-greedy split on the remainder: exploit picks from active circles by
+ *      circleWeight; explore picks from all eligible by circleWeight.
+ *
+ * circleWeight already factors in availableMerchantsCount, so capacity is
+ * respected on both branches.
+ */
 export function selectCircle(eligible: readonly CircleForRouting[]): CircleForRouting | null {
 	if (eligible.length === 0) {
 		return null;
 	}
 
+	const bootstrapCircles = eligible.filter((c) => c.metrics.circleStatus === "bootstrap");
 	const activeCircles = eligible.filter((c) => c.metrics.circleStatus === "active");
 
-	const isExplore = Math.random() < EPSILON;
+	const r = Math.random();
+
+	// Bootstrap reserve: dedicated share for bootstrap circles to graduate.
+	if (r < BOOTSTRAP_RESERVE && bootstrapCircles.length > 0) {
+		const weights = bootstrapCircles.map(circleWeight);
+		return weightedRandomChoice(bootstrapCircles, weights);
+	}
+
+	const isExplore = r < BOOTSTRAP_RESERVE + EPSILON;
 
 	if (isExplore) {
-		// Explore: all eligible circles with status-aware weights
+		// Explore: all eligible circles with status-aware, capacity-aware weights.
 		const weights = eligible.map(circleWeight);
 		return weightedRandomChoice(eligible, weights);
 	}
 
-	// Exploit: only active circles, weighted by score
+	// Exploit: only active circles, weighted by capacity-aware score.
 	if (activeCircles.length === 0) {
-		// Fallback: no active circles, pick from all eligible with status-aware weights
+		// Fallback: no active circles, pick from all eligible by circleWeight.
 		const weights = eligible.map(circleWeight);
 		return weightedRandomChoice(eligible, weights);
 	}
 
-	const weights = activeCircles.map((c) => c.metrics.circleScore);
+	const weights = activeCircles.map(circleWeight);
 	return weightedRandomChoice(activeCircles, weights);
 }
 

--- a/src/orders/internal/routing/subgraph/index.ts
+++ b/src/orders/internal/routing/subgraph/index.ts
@@ -30,12 +30,15 @@ export function getCirclesForRouting(
 				(message, cause, d) =>
 					new OrderRoutingError(message, { code: "VALIDATION_ERROR", cause, context: { data: d } }),
 			).map((validated) => {
+				// Filter by availableMerchantsCount (point-in-time routing capacity)
+				// rather than activeMerchantsCount, which also counts merchants with
+				// pending unstake requests and overstates real capacity.
 				const circles = validated.circles.filter(
-					(item) => Number(item.metrics.scoreState.activeMerchantsCount) > 0,
+					(item) => Number(item.metrics.scoreState.availableMerchantsCount) > 0,
 				);
 				logger.info("fetched circles from subgraph", {
 					total: validated.circles.length,
-					withActiveMerchants: circles.length,
+					withAvailableMerchants: circles.length,
 					circles,
 				});
 				return circles;

--- a/src/orders/internal/routing/subgraph/queries.ts
+++ b/src/orders/internal/routing/subgraph/queries.ts
@@ -16,6 +16,7 @@ export const CIRCLES_FOR_ROUTING_QUERY = /* GraphQL */ `
         circleStatus
         scoreState {
           activeMerchantsCount
+          availableMerchantsCount
         }
       }
     }

--- a/src/orders/internal/routing/types.ts
+++ b/src/orders/internal/routing/types.ts
@@ -9,6 +9,7 @@ export type { PublicClientLike } from "../../../types";
 
 export interface CircleScoreState {
 	readonly activeMerchantsCount: number;
+	readonly availableMerchantsCount: number;
 }
 
 export interface CircleMetrics {

--- a/src/orders/internal/routing/validation.ts
+++ b/src/orders/internal/routing/validation.ts
@@ -5,6 +5,7 @@ import { ZodAddressSchema } from "../../../validation/schemas.validation";
 
 export const ZodCircleScoreStateSchema = z.object({
 	activeMerchantsCount: z.coerce.number(),
+	availableMerchantsCount: z.coerce.number(),
 });
 
 export const ZodCircleMetricsForRoutingSchema = z.object({

--- a/test/orders/internal/routing/routing.test.ts
+++ b/test/orders/internal/routing/routing.test.ts
@@ -10,17 +10,36 @@ import type { CircleForRouting } from "../../../../src/orders/internal/routing/t
 
 // ── Helpers ─────────────────────────────────────────────────────────────
 
-function makeCircle(
-	overrides: Partial<CircleForRouting> & { circleId: string },
-): CircleForRouting {
+type CircleOverrides = {
+	circleId: string;
+	currency?: string;
+	metrics?: {
+		circleScore?: number;
+		circleStatus?: string;
+		scoreState?: {
+			activeMerchantsCount?: number;
+			availableMerchantsCount?: number;
+		};
+	};
+};
+
+function makeCircle(overrides: CircleOverrides): CircleForRouting {
+	const active = overrides.metrics?.scoreState?.activeMerchantsCount ?? 5;
 	return {
-		currency: "INR",
+		circleId: overrides.circleId,
+		currency: overrides.currency ?? "INR",
 		metrics: {
-			circleScore: 100,
-			circleStatus: "active",
-			scoreState: { activeMerchantsCount: 5 },
+			circleScore: overrides.metrics?.circleScore ?? 100,
+			circleStatus: overrides.metrics?.circleStatus ?? "active",
+			scoreState: {
+				activeMerchantsCount: active,
+				// Default availableMerchantsCount to activeMerchantsCount so
+				// pre-existing fixtures keep working; tests that need them to
+				// differ can override explicitly.
+				availableMerchantsCount:
+					overrides.metrics?.scoreState?.availableMerchantsCount ?? active,
+			},
 		},
-		...overrides,
 	};
 }
 
@@ -37,52 +56,115 @@ function seedRandom(values: number[]) {
 // ── circleWeight ────────────────────────────────────────────────────────
 
 describe("circleWeight", () => {
-	it("returns raw score for active circles", () => {
+	it("multiplies score by availableMerchantsCount for active circles", () => {
 		const circle = makeCircle({
 			circleId: "1",
-			metrics: { circleScore: 80, circleStatus: "active", scoreState: { activeMerchantsCount: 3 } },
+			metrics: {
+				circleScore: 80,
+				circleStatus: "active",
+				scoreState: { activeMerchantsCount: 3, availableMerchantsCount: 3 },
+			},
 		});
-		expect(circleWeight(circle)).toBe(80);
+		expect(circleWeight(circle)).toBe(80 * 3);
 	});
 
-	it("caps bootstrap circles at 25", () => {
+	it("caps bootstrap base at 25 before multiplying by capacity", () => {
 		const circle = makeCircle({
 			circleId: "1",
-			metrics: { circleScore: 50, circleStatus: "bootstrap", scoreState: { activeMerchantsCount: 1 } },
+			metrics: {
+				circleScore: 50,
+				circleStatus: "bootstrap",
+				scoreState: { activeMerchantsCount: 4, availableMerchantsCount: 4 },
+			},
 		});
-		expect(circleWeight(circle)).toBe(25);
+		// base = min(50, 25) = 25; weight = 25 × 4
+		expect(circleWeight(circle)).toBe(25 * 4);
 	});
 
-	it("returns raw score for bootstrap circles when score < 25", () => {
+	it("uses raw score for bootstrap circles when score < 25", () => {
 		const circle = makeCircle({
 			circleId: "1",
-			metrics: { circleScore: 10, circleStatus: "bootstrap", scoreState: { activeMerchantsCount: 1 } },
+			metrics: {
+				circleScore: 10,
+				circleStatus: "bootstrap",
+				scoreState: { activeMerchantsCount: 2, availableMerchantsCount: 2 },
+			},
 		});
-		expect(circleWeight(circle)).toBe(10);
+		expect(circleWeight(circle)).toBe(10 * 2);
 	});
 
-	it("scales paused circles by 0.3", () => {
+	it("scales paused base by 0.3 before multiplying by capacity", () => {
 		const circle = makeCircle({
 			circleId: "1",
-			metrics: { circleScore: 100, circleStatus: "paused", scoreState: { activeMerchantsCount: 2 } },
+			metrics: {
+				circleScore: 100,
+				circleStatus: "paused",
+				scoreState: { activeMerchantsCount: 2, availableMerchantsCount: 2 },
+			},
 		});
-		expect(circleWeight(circle)).toBeCloseTo(30);
+		// base = 100 × 0.3 = 30; weight = 30 × 2
+		expect(circleWeight(circle)).toBeCloseTo(60);
 	});
 
-	it("returns raw score for unknown status", () => {
+	it("treats unknown status as raw score base", () => {
 		const circle = makeCircle({
 			circleId: "1",
-			metrics: { circleScore: 60, circleStatus: "unknown", scoreState: { activeMerchantsCount: 0 } },
+			metrics: {
+				circleScore: 60,
+				circleStatus: "unknown",
+				scoreState: { activeMerchantsCount: 4, availableMerchantsCount: 4 },
+			},
 		});
-		expect(circleWeight(circle)).toBe(60);
+		expect(circleWeight(circle)).toBe(60 * 4);
+	});
+
+	it("returns zero when availableMerchantsCount is zero, regardless of score", () => {
+		const circle = makeCircle({
+			circleId: "1",
+			metrics: {
+				circleScore: 90,
+				circleStatus: "active",
+				scoreState: { activeMerchantsCount: 5, availableMerchantsCount: 0 },
+			},
+		});
+		expect(circleWeight(circle)).toBe(0);
 	});
 
 	it("handles zero score", () => {
 		const circle = makeCircle({
 			circleId: "1",
-			metrics: { circleScore: 0, circleStatus: "active", scoreState: { activeMerchantsCount: 0 } },
+			metrics: {
+				circleScore: 0,
+				circleStatus: "active",
+				scoreState: { activeMerchantsCount: 5, availableMerchantsCount: 5 },
+			},
 		});
 		expect(circleWeight(circle)).toBe(0);
+	});
+
+	it("equalizes per-merchant load ratio to score ratio", () => {
+		// Per-merchant load = weight / availableMerchantsCount = base score.
+		// So the ratio of per-merchant loads between two active circles
+		// equals their score ratio, independent of merchant pool sizes.
+		const big = makeCircle({
+			circleId: "1",
+			metrics: {
+				circleScore: 50,
+				circleStatus: "active",
+				scoreState: { activeMerchantsCount: 20, availableMerchantsCount: 20 },
+			},
+		});
+		const small = makeCircle({
+			circleId: "2",
+			metrics: {
+				circleScore: 80,
+				circleStatus: "active",
+				scoreState: { activeMerchantsCount: 5, availableMerchantsCount: 5 },
+			},
+		});
+		const bigPerMerchant = circleWeight(big) / big.metrics.scoreState.availableMerchantsCount;
+		const smallPerMerchant = circleWeight(small) / small.metrics.scoreState.availableMerchantsCount;
+		expect(smallPerMerchant / bigPerMerchant).toBeCloseTo(80 / 50);
 	});
 });
 
@@ -107,6 +189,21 @@ describe("filterEligibleCircles", () => {
 
 	it("returns empty for empty input", () => {
 		expect(filterEligibleCircles([], "INR")).toEqual([]);
+	});
+
+	it("excludes circles with zero availableMerchantsCount", () => {
+		const withCap = makeCircle({
+			circleId: "1",
+			currency: "INR",
+			metrics: { scoreState: { activeMerchantsCount: 4, availableMerchantsCount: 4 } },
+		});
+		const withoutCap = makeCircle({
+			circleId: "2",
+			currency: "INR",
+			metrics: { scoreState: { activeMerchantsCount: 4, availableMerchantsCount: 0 } },
+		});
+		const result = filterEligibleCircles([withCap, withoutCap], "INR");
+		expect(result.map((c) => c.circleId)).toEqual(["1"]);
 	});
 });
 
@@ -147,19 +244,27 @@ describe("selectCircle", () => {
 		expect(result).toBe(active);
 	});
 
-	it("explores: picks from all eligible circles (Math.random < 0.25)", () => {
+	it("explores: picks from all eligible circles (BOOTSTRAP_RESERVE <= r < 0.35)", () => {
 		const active = makeCircle({
 			circleId: "1",
-			metrics: { circleScore: 100, circleStatus: "active", scoreState: { activeMerchantsCount: 5 } },
+			metrics: {
+				circleScore: 100,
+				circleStatus: "active",
+				scoreState: { activeMerchantsCount: 5, availableMerchantsCount: 5 },
+			},
 		});
 		const paused = makeCircle({
 			circleId: "2",
-			metrics: { circleScore: 100, circleStatus: "paused", scoreState: { activeMerchantsCount: 2 } },
+			metrics: {
+				circleScore: 100,
+				circleStatus: "paused",
+				scoreState: { activeMerchantsCount: 2, availableMerchantsCount: 2 },
+			},
 		});
 
-		// First random < 0.25 → explore; second random picks high enough to land on paused
-		// Weights: active=100, paused=30 → total=130
-		// To pick paused: rand must exceed 100 → need > 100/130 ≈ 0.77
+		// r=0.1: not in reserve (0.1 < 0.1 is false), 0.1 < 0.35 → explore.
+		// Capacity-aware weights: active=100×5=500, paused=30×2=60 → total=560.
+		// Second random 0.9 → rand = 0.9 × 560 = 504. 504-500=4, 4-60=-56 → paused.
 		seedRandom([0.1, 0.9]);
 		const result = selectCircle([active, paused]);
 		expect(result).toBe(paused);
@@ -201,6 +306,49 @@ describe("selectCircle", () => {
 
 		// highScore (900) should be picked ~90% of the time
 		expect(counts["1"]).toBeGreaterThan(counts["2"] * 2);
+	});
+
+	it("bootstrap reserve: picks only from bootstrap circles when r < 0.1", () => {
+		const active = makeCircle({
+			circleId: "1",
+			metrics: {
+				circleScore: 900,
+				circleStatus: "active",
+				scoreState: { activeMerchantsCount: 10, availableMerchantsCount: 10 },
+			},
+		});
+		const bootstrap = makeCircle({
+			circleId: "2",
+			metrics: {
+				circleScore: 20,
+				circleStatus: "bootstrap",
+				scoreState: { activeMerchantsCount: 1, availableMerchantsCount: 1 },
+			},
+		});
+
+		// r=0.05 → bootstrap reserve branch.
+		// Even though active has weight 9000 vs bootstrap 20, reserve picks
+		// from bootstrap-only.
+		seedRandom([0.05, 0.0]);
+		const result = selectCircle([active, bootstrap]);
+		expect(result).toBe(bootstrap);
+	});
+
+	it("bootstrap reserve falls through to e-greedy when no bootstrap circles exist", () => {
+		const active = makeCircle({
+			circleId: "1",
+			metrics: {
+				circleScore: 100,
+				circleStatus: "active",
+				scoreState: { activeMerchantsCount: 5, availableMerchantsCount: 5 },
+			},
+		});
+
+		// r=0.05 — would hit reserve, but no bootstrap circles → falls through.
+		// 0.05 < 0.35 → explore branch over active alone.
+		seedRandom([0.05, 0.0]);
+		const result = selectCircle([active]);
+		expect(result).toBe(active);
 	});
 });
 


### PR DESCRIPTION
Pairs with subgraph PR adding availableMerchantsCount on CircleScoreState.

circleWeight is now base(score, status) × availableMerchantsCount (linear). Per-merchant load ratio between any two circles now equals their score ratio — bounded by quality, not by structural pool-size disparity. The previous formula used raw score with no capacity term, which let a smaller, lower-scored circle's merchants get over-loaded (e.g. a circle with 5 merchants at score 40 served 7.2 orders/merchant while a circle with 20 merchants at score 70 served 3.2).

selectCircle:
- Exploit branch now uses circleWeight (was raw score), so capacity is respected on the 75% path, not just on explore.
- New bootstrap reserve: ~10% of routing decisions go only to bootstrap circles, weighted by their own capacity. This guarantees new circles enough flow to accumulate the order history they need to graduate, instead of being throttled to ~6% by the score-weighted explore math.
- Single Math.random() call drives both branch decisions for cleaner deterministic test setup; reserve falls through to e-greedy when no bootstrap circles exist.

filterEligibleCircles + subgraph fetch:
- Drop circles with availableMerchantsCount == 0 up front. Saves the on-chain eligibility-validate retry budget for circles that can actually fulfill, and stops zero-capacity circles from biasing the validation-retry survivors.