### PR TITLE
fix(orders): read small-order fixed fee per order type

### DIFF
--- a/.changeset/small-order-fixed-fee-per-order-type.md
+++ b/.changeset/small-order-fixed-fee-per-order-type.md
@@ -1,0 +1,5 @@
+---
+"@p2pdotme/sdk": minor
+---
+
+Fix small-order fixed fee to be per order type. The Diamond exposes the fixed fee via three per-order-type getters (`getSmallOrderFixedFeeBuy` / `Sell` / `Pay`), but the SDK only read a single non-existent `getSmallOrderFixedFee(currency)`. `getFeeConfig({ currency })` now reads all three and returns `smallOrderFixedFee` as `{ buy, sell, pay }` (the per-currency `smallOrderThreshold` is unchanged).

--- a/.changeset/small-order-fixed-fee-per-order-type.md
+++ b/.changeset/small-order-fixed-fee-per-order-type.md
@@ -1,5 +1,0 @@
----
-"@p2pdotme/sdk": minor
----
-
-Fix small-order fixed fee to be per order type. The Diamond exposes the fixed fee via three per-order-type getters (`getSmallOrderFixedFeeBuy` / `Sell` / `Pay`), but the SDK only read a single non-existent `getSmallOrderFixedFee(currency)`. `getFeeConfig({ currency })` now reads all three and returns `smallOrderFixedFee` as `{ buy, sell, pay }` (the per-currency `smallOrderThreshold` is unchanged).

--- a/src/contracts/abis/order-processor-facet.ts
+++ b/src/contracts/abis/order-processor-facet.ts
@@ -1,7 +1,8 @@
 /**
  * Minimal ABI fragments for reads on OrderProcessor storage via the Diamond.
  * `getOrdersById`, `getAdditionalOrderDetails`, and the per-currency small-order
- * fee config getters (`getSmallOrderThreshold`, `getSmallOrderFixedFee`).
+ * fee config getters (`getSmallOrderThreshold`, and the per-order-type
+ * `getSmallOrderFixedFeeBuy` / `Sell` / `Pay`).
  */
 export const orderProcessorFacetAbi = [
 	{
@@ -77,7 +78,21 @@ export const orderProcessorFacetAbi = [
 	},
 	{
 		type: "function",
-		name: "getSmallOrderFixedFee",
+		name: "getSmallOrderFixedFeeBuy",
+		stateMutability: "view",
+		inputs: [{ name: "currency", type: "bytes32" }],
+		outputs: [{ name: "", type: "uint256" }],
+	},
+	{
+		type: "function",
+		name: "getSmallOrderFixedFeeSell",
+		stateMutability: "view",
+		inputs: [{ name: "currency", type: "bytes32" }],
+		outputs: [{ name: "", type: "uint256" }],
+	},
+	{
+		type: "function",
+		name: "getSmallOrderFixedFeePay",
 		stateMutability: "view",
 		inputs: [{ name: "currency", type: "bytes32" }],
 		outputs: [{ name: "", type: "uint256" }],

--- a/src/contracts/order-processor/index.ts
+++ b/src/contracts/order-processor/index.ts
@@ -69,23 +69,26 @@ export function readOrderMulticall(
 
 export interface RawFeeConfig {
 	smallOrderThreshold: bigint;
-	smallOrderFixedFee: {
-		buy: bigint;
-		sell: bigint;
-		pay: bigint;
-	};
+	smallOrderFixedFee: bigint;
 }
 
+const FIXED_FEE_GETTER_BY_ORDER_TYPE = [
+	"getSmallOrderFixedFeeBuy",
+	"getSmallOrderFixedFeeSell",
+	"getSmallOrderFixedFeePay",
+] as const;
+
 /**
- * Reads the per-currency small-order threshold and the per-order-type fixed fees
- * (buy/sell/pay) from the Diamond. Uses viem `multicall` when available (1 RPC)
- * and falls back to parallel `readContract` calls otherwise. Amounts are returned
- * as 6-decimal bigints.
+ * Reads the per-currency small-order threshold and the fixed fee for the given
+ * order type (0=buy, 1=sell, 2=pay) from the Diamond. Uses viem `multicall` when
+ * available (1 RPC) and falls back to two parallel `readContract` calls otherwise.
+ * Amounts are returned as 6-decimal bigints.
  */
 export function readFeeConfigMulticall(
 	publicClient: PublicClientLike,
 	diamondAddress: Address,
 	currency: string,
+	orderType: 0 | 1 | 2,
 ): ResultAsync<RawFeeConfig, Error> {
 	const currencyHex = stringToHex(currency, { size: 32 });
 	const calls = [
@@ -98,19 +101,7 @@ export function readFeeConfigMulticall(
 		{
 			address: diamondAddress,
 			abi: ABIS.FACETS.ORDER_PROCESSOR,
-			functionName: "getSmallOrderFixedFeeBuy",
-			args: [currencyHex] as const,
-		},
-		{
-			address: diamondAddress,
-			abi: ABIS.FACETS.ORDER_PROCESSOR,
-			functionName: "getSmallOrderFixedFeeSell",
-			args: [currencyHex] as const,
-		},
-		{
-			address: diamondAddress,
-			abi: ABIS.FACETS.ORDER_PROCESSOR,
-			functionName: "getSmallOrderFixedFeePay",
+			functionName: FIXED_FEE_GETTER_BY_ORDER_TYPE[orderType],
 			args: [currencyHex] as const,
 		},
 	];
@@ -118,31 +109,18 @@ export function readFeeConfigMulticall(
 	const toError = (error: unknown) =>
 		new Error("Fee config contract read failed", { cause: error });
 
-	const toFeeConfig = ([smallOrderThreshold, buy, sell, pay]: [
-		bigint,
-		bigint,
-		bigint,
-		bigint,
-	]): RawFeeConfig => ({
-		smallOrderThreshold,
-		smallOrderFixedFee: { buy, sell, pay },
-	});
-
 	const exec = async (): Promise<RawFeeConfig> => {
 		if (publicClient.multicall) {
-			const results = (await publicClient.multicall({
+			const [smallOrderThreshold, smallOrderFixedFee] = (await publicClient.multicall({
 				contracts: calls,
 				allowFailure: false,
-			})) as [bigint, bigint, bigint, bigint];
-			return toFeeConfig(results);
+			})) as [bigint, bigint];
+			return { smallOrderThreshold, smallOrderFixedFee };
 		}
-		const results = (await Promise.all(calls.map((c) => publicClient.readContract(c)))) as [
-			bigint,
-			bigint,
-			bigint,
-			bigint,
-		];
-		return toFeeConfig(results);
+		const [smallOrderThreshold, smallOrderFixedFee] = (await Promise.all(
+			calls.map((c) => publicClient.readContract(c)),
+		)) as [bigint, bigint];
+		return { smallOrderThreshold, smallOrderFixedFee };
 	};
 
 	return ResultAsync.fromPromise(exec(), toError);

--- a/src/contracts/order-processor/index.ts
+++ b/src/contracts/order-processor/index.ts
@@ -72,23 +72,23 @@ export interface RawFeeConfig {
 	smallOrderFixedFee: bigint;
 }
 
-const FIXED_FEE_GETTER_BY_ORDER_TYPE = [
-	"getSmallOrderFixedFeeBuy",
-	"getSmallOrderFixedFeeSell",
-	"getSmallOrderFixedFeePay",
-] as const;
+const FIXED_FEE_GETTER_BY_ORDER_TYPE = {
+	buy: "getSmallOrderFixedFeeBuy",
+	sell: "getSmallOrderFixedFeeSell",
+	pay: "getSmallOrderFixedFeePay",
+} as const;
 
 /**
  * Reads the per-currency small-order threshold and the fixed fee for the given
- * order type (0=buy, 1=sell, 2=pay) from the Diamond. Uses viem `multicall` when
- * available (1 RPC) and falls back to two parallel `readContract` calls otherwise.
- * Amounts are returned as 6-decimal bigints.
+ * order type from the Diamond. Uses viem `multicall` when available (1 RPC) and
+ * falls back to two parallel `readContract` calls otherwise. Amounts are
+ * returned as 6-decimal bigints.
  */
 export function readFeeConfigMulticall(
 	publicClient: PublicClientLike,
 	diamondAddress: Address,
 	currency: string,
-	orderType: 0 | 1 | 2,
+	orderType: "buy" | "sell" | "pay",
 ): ResultAsync<RawFeeConfig, Error> {
 	const currencyHex = stringToHex(currency, { size: 32 });
 	const calls = [

--- a/src/contracts/order-processor/index.ts
+++ b/src/contracts/order-processor/index.ts
@@ -69,13 +69,18 @@ export function readOrderMulticall(
 
 export interface RawFeeConfig {
 	smallOrderThreshold: bigint;
-	smallOrderFixedFee: bigint;
+	smallOrderFixedFee: {
+		buy: bigint;
+		sell: bigint;
+		pay: bigint;
+	};
 }
 
 /**
- * Reads the per-currency small-order threshold and fixed fee from the Diamond.
- * Uses viem `multicall` when available (1 RPC) and falls back to two parallel
- * `readContract` calls otherwise. Amounts are returned as 6-decimal bigints.
+ * Reads the per-currency small-order threshold and the per-order-type fixed fees
+ * (buy/sell/pay) from the Diamond. Uses viem `multicall` when available (1 RPC)
+ * and falls back to parallel `readContract` calls otherwise. Amounts are returned
+ * as 6-decimal bigints.
  */
 export function readFeeConfigMulticall(
 	publicClient: PublicClientLike,
@@ -93,7 +98,19 @@ export function readFeeConfigMulticall(
 		{
 			address: diamondAddress,
 			abi: ABIS.FACETS.ORDER_PROCESSOR,
-			functionName: "getSmallOrderFixedFee",
+			functionName: "getSmallOrderFixedFeeBuy",
+			args: [currencyHex] as const,
+		},
+		{
+			address: diamondAddress,
+			abi: ABIS.FACETS.ORDER_PROCESSOR,
+			functionName: "getSmallOrderFixedFeeSell",
+			args: [currencyHex] as const,
+		},
+		{
+			address: diamondAddress,
+			abi: ABIS.FACETS.ORDER_PROCESSOR,
+			functionName: "getSmallOrderFixedFeePay",
 			args: [currencyHex] as const,
 		},
 	];
@@ -101,18 +118,31 @@ export function readFeeConfigMulticall(
 	const toError = (error: unknown) =>
 		new Error("Fee config contract read failed", { cause: error });
 
+	const toFeeConfig = ([smallOrderThreshold, buy, sell, pay]: [
+		bigint,
+		bigint,
+		bigint,
+		bigint,
+	]): RawFeeConfig => ({
+		smallOrderThreshold,
+		smallOrderFixedFee: { buy, sell, pay },
+	});
+
 	const exec = async (): Promise<RawFeeConfig> => {
 		if (publicClient.multicall) {
-			const [smallOrderThreshold, smallOrderFixedFee] = (await publicClient.multicall({
+			const results = (await publicClient.multicall({
 				contracts: calls,
 				allowFailure: false,
-			})) as [bigint, bigint];
-			return { smallOrderThreshold, smallOrderFixedFee };
+			})) as [bigint, bigint, bigint, bigint];
+			return toFeeConfig(results);
 		}
-		const [smallOrderThreshold, smallOrderFixedFee] = (await Promise.all(
-			calls.map((c) => publicClient.readContract(c)),
-		)) as [bigint, bigint];
-		return { smallOrderThreshold, smallOrderFixedFee };
+		const results = (await Promise.all(calls.map((c) => publicClient.readContract(c)))) as [
+			bigint,
+			bigint,
+			bigint,
+			bigint,
+		];
+		return toFeeConfig(results);
 	};
 
 	return ResultAsync.fromPromise(exec(), toError);

--- a/src/orders/README.md
+++ b/src/orders/README.md
@@ -66,18 +66,14 @@ Single order via Diamond multicall (with a parallel-`readContract` fallback).
 
 Paginated list of a user's orders from the subgraph, newest first. `skip` defaults to `0`; `limit` defaults to `20`, max `100`.
 
-### `orders.getFeeConfig({ currency })` → `ResultAsync<FeeConfig, OrdersError>`
+### `orders.getFeeConfig({ currency, orderType })` → `ResultAsync<FeeConfig, OrdersError>`
 
-Per-currency small-order threshold + per-order-type fixed fees, read via multicall.
+Per-currency small-order threshold + the fixed fee for the given order type (`0` buy, `1` sell, `2` pay), read via multicall.
 
 ```ts
 interface FeeConfig {
   smallOrderThreshold: bigint;  // orders ≤ this are billed the fixed fee (per currency)
-  smallOrderFixedFee: {         // 6 decimals, per order type
-    buy: bigint;
-    sell: bigint;
-    pay: bigint;
-  };
+  smallOrderFixedFee: bigint;   // 6 decimals, for the requested order type
 }
 ```
 

--- a/src/orders/README.md
+++ b/src/orders/README.md
@@ -68,12 +68,16 @@ Paginated list of a user's orders from the subgraph, newest first. `skip` defaul
 
 ### `orders.getFeeConfig({ currency })` → `ResultAsync<FeeConfig, OrdersError>`
 
-Per-currency small-order threshold + fixed fee, read via multicall.
+Per-currency small-order threshold + per-order-type fixed fees, read via multicall.
 
 ```ts
 interface FeeConfig {
-  smallOrderThreshold: bigint;  // orders ≤ this are billed the fixed fee
-  smallOrderFixedFee: bigint;   // 6 decimals
+  smallOrderThreshold: bigint;  // orders ≤ this are billed the fixed fee (per currency)
+  smallOrderFixedFee: {         // 6 decimals, per order type
+    buy: bigint;
+    sell: bigint;
+    pay: bigint;
+  };
 }
 ```
 

--- a/src/orders/README.md
+++ b/src/orders/README.md
@@ -68,7 +68,7 @@ Paginated list of a user's orders from the subgraph, newest first. `skip` defaul
 
 ### `orders.getFeeConfig({ currency, orderType })` → `ResultAsync<FeeConfig, OrdersError>`
 
-Per-currency small-order threshold + the fixed fee for the given order type (`0` buy, `1` sell, `2` pay), read via multicall.
+Per-currency small-order threshold + the fixed fee for the given order type (`"buy" | "sell" | "pay"`), read via multicall.
 
 ```ts
 interface FeeConfig {

--- a/src/orders/client.ts
+++ b/src/orders/client.ts
@@ -171,18 +171,21 @@ export function createOrders(config: OrdersConfig): OrdersClient {
 						context: { params: d },
 					}),
 			)
-				.asyncAndThen(({ currency }) =>
-					readFeeConfigMulticall(publicClient, diamondAddress, currency).mapErr(
+				.asyncAndThen(({ currency, orderType }) =>
+					readFeeConfigMulticall(publicClient, diamondAddress, currency, orderType).mapErr(
 						(cause) =>
 							new OrdersError("Fee config contract read failed", {
 								code: "CONTRACT_READ_FAILED",
 								cause,
-								context: { currency },
+								context: { currency, orderType },
 							}),
 					),
 				)
 				.map((config) => {
-					logger.debug("getFeeConfig resolved", { currency: params.currency });
+					logger.debug("getFeeConfig resolved", {
+						currency: params.currency,
+						orderType: params.orderType,
+					});
 					return config;
 				});
 		},

--- a/src/orders/types.ts
+++ b/src/orders/types.ts
@@ -64,14 +64,21 @@ export interface Order {
 }
 
 /**
- * Per-currency small-order fee config read from the Diamond.
- * Amounts are 6-decimal bigints.
+ * Per-currency small-order fee config read from the Diamond. The threshold is
+ * per-currency; the fixed fee varies by order type. Amounts are 6-decimal bigints.
  */
 export interface FeeConfig {
 	/** Order amounts at or below this threshold are billed the fixed fee. */
 	smallOrderThreshold: bigint;
-	/** Fixed fee applied to small orders (6 decimals). */
-	smallOrderFixedFee: bigint;
+	/** Fixed fee applied to small orders, per order type (6 decimals). */
+	smallOrderFixedFee: {
+		/** Fixed fee for small BUY orders. */
+		buy: bigint;
+		/** Fixed fee for small SELL orders. */
+		sell: bigint;
+		/** Fixed fee for small PAY orders. */
+		pay: bigint;
+	};
 }
 
 // ── Client config ───────────────────────────────────────────────────────

--- a/src/orders/types.ts
+++ b/src/orders/types.ts
@@ -64,21 +64,15 @@ export interface Order {
 }
 
 /**
- * Per-currency small-order fee config read from the Diamond. The threshold is
- * per-currency; the fixed fee varies by order type. Amounts are 6-decimal bigints.
+ * Small-order fee config read from the Diamond for one currency + order type.
+ * The threshold is per-currency; the fixed fee is per order type.
+ * Amounts are 6-decimal bigints.
  */
 export interface FeeConfig {
 	/** Order amounts at or below this threshold are billed the fixed fee. */
 	smallOrderThreshold: bigint;
-	/** Fixed fee applied to small orders, per order type (6 decimals). */
-	smallOrderFixedFee: {
-		/** Fixed fee for small BUY orders. */
-		buy: bigint;
-		/** Fixed fee for small SELL orders. */
-		sell: bigint;
-		/** Fixed fee for small PAY orders. */
-		pay: bigint;
-	};
+	/** Fixed fee applied to small orders of the requested order type (6 decimals). */
+	smallOrderFixedFee: bigint;
 }
 
 // ── Client config ───────────────────────────────────────────────────────

--- a/src/orders/validation.ts
+++ b/src/orders/validation.ts
@@ -12,6 +12,7 @@ export type GetOrderParams = z.infer<typeof ZodGetOrderParamsSchema>;
 
 export const ZodGetFeeConfigParamsSchema = z.object({
 	currency: ZodCurrencySchema,
+	orderType: z.union([z.literal(0), z.literal(1), z.literal(2)]),
 });
 
 export type GetFeeConfigParams = z.infer<typeof ZodGetFeeConfigParamsSchema>;

--- a/src/orders/validation.ts
+++ b/src/orders/validation.ts
@@ -12,7 +12,7 @@ export type GetOrderParams = z.infer<typeof ZodGetOrderParamsSchema>;
 
 export const ZodGetFeeConfigParamsSchema = z.object({
 	currency: ZodCurrencySchema,
-	orderType: z.union([z.literal(0), z.literal(1), z.literal(2)]),
+	orderType: z.enum(["buy", "sell", "pay"]),
 });
 
 export type GetFeeConfigParams = z.infer<typeof ZodGetFeeConfigParamsSchema>;


### PR DESCRIPTION
## What was wrong

The Diamond exposes the small-order fixed fee via **three per-order-type getters** — `getSmallOrderFixedFeeBuy` / `Sell` / `Pay(currency)` (see `GetterFacet.sol`). The SDK instead read a single **non-existent** `getSmallOrderFixedFee(currency)`, modeling the fee as per-currency only.

## Fix

`getFeeConfig` now takes the order type (the SDK's public `OrderType` — `"buy" | "sell" | "pay"`) and reads only the relevant fee getter alongside the (unchanged, per-currency) `getSmallOrderThreshold` — 2 reads in one multicall, keeping RPC usage minimal for rate-limited/free endpoints.

```ts
getFeeConfig({ currency, orderType }) → {   // orderType: "buy" | "sell" | "pay"
  smallOrderThreshold: bigint,              // per currency (unchanged)
  smallOrderFixedFee: bigint,               // for the requested order type (6 decimals)
}
```

### Changes
- `src/contracts/abis/order-processor-facet.ts` — replace the non-existent getter with the three real ones (`Buy`/`Sell`/`Pay`).
- `src/contracts/order-processor/index.ts` — `readFeeConfigMulticall(publicClient, diamondAddress, currency, orderType)` picks the matching getter; reads threshold + one fee in one multicall.
- `src/orders/validation.ts` — `getFeeConfig` params now require `orderType` (`z.enum(["buy", "sell", "pay"])`).
- `src/orders/types.ts` — `FeeConfig.smallOrderFixedFee` stays a flat `bigint`.
- `src/orders/README.md` — updated docs.

## Breaking change

`getFeeConfig` now requires `orderType` in its params. The return shape is unchanged from the released SDK (`smallOrderFixedFee: bigint`), but the value is now the fee for the requested order type.

## Verification
- `bun run typecheck` — clean
- `bun run build` — success
- `bun run test` — 392 passing (only unrelated `brl.test.ts` fails, due to missing `PIX_PROXY_URL` env var)

🤖 Generated with [Claude Code](https://claude.com/claude-code)