### PR TITLE
feat(payment-proof): add @p2pdotme/sdk/payment-proof module

### DIFF
--- a/.changeset/payment-proof-module.md
+++ b/.changeset/payment-proof-module.md
@@ -1,0 +1,5 @@
+---
+"@p2pdotme/sdk": minor
+---
+
+Add `@p2pdotme/sdk/payment-proof` — a `ResultAsync` client for the encrypted-payment-proof server. Lets integrators surface a proof pill (`getOrderProofRequest`), raise a request (`requestProof`), read feature config (`getPublicConfig`), and list/download proof files for completed SELL/PAY orders. Wraps the published `p2pme-encrypted-payment-proof` client and follows the SDK's factory + no-throw conventions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `@p2pdotme/sdk/fraud-engine` — fraud detection, device fingerprinting (FingerprintJS), SEON session signals, encrypted activity logging.
 - `@p2pdotme/sdk/zkkyc` — ZK KYC: tx calldata preparation for Reclaim social verify, Aadhaar, ZK Passport; plus UX flow orchestrators.
 - `@p2pdotme/sdk/country` — country/currency metadata, payment field configs, per-currency validators.
+- `@p2pdotme/sdk/payment-proof` — client for the encrypted-payment-proof server: `getPublicConfig`, `getOrderProofRequest`, `requestProof`, `listProofFiles`, `downloadProof` for completed SELL/PAY orders. Thin `ResultAsync` wrapper over the published `p2pme-encrypted-payment-proof` client.
 
 Framework-agnostic core. Wallet-agnostic — consumers bring their own viem `PublicClient` (reads) and optionally a `WalletClient` (writes).
 
@@ -85,6 +86,7 @@ src/
 ├── fraud-engine/
 ├── zkkyc/                  # createZkkyc + createReclaimFlow + createZkPassportFlow
 ├── country/                # COUNTRY_OPTIONS, PAYMENT_ID_FIELDS, per-currency validators
+├── payment-proof/          # ResultAsync client over p2pme-encrypted-payment-proof
 └── react/                  # SdkProvider + hooks
 ```
 
@@ -167,6 +169,7 @@ SEON and FingerprintJS are direct deps — the SDK owns their lifecycle. Browser
 - `@seontechnologies/seon-javascript-sdk` — SEON session collection.
 - `@fingerprintjs/fingerprintjs` — browser fingerprinting.
 - `@noble/ciphers`, `@noble/curves`, `@noble/hashes` — ECIES + AES-GCM (bundled; not re-exported).
+- `p2pme-encrypted-payment-proof` — headless proof-server client wrapped by `@p2pdotme/sdk/payment-proof`.
 - `react` — optional peer (for `./react` export).
 - `@reclaimprotocol/js-sdk` — optional peer (zkkyc Reclaim flow only).
 - `@zkpassport/sdk` — optional peer (zkkyc ZK Passport flow only).

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ bun add @zkpassport/sdk                  # only for zkkyc ZK Passport flow
 | `@p2pdotme/sdk/fraud-engine` | [Fraud detection](./src/fraud-engine/README.md), device fingerprinting, SEON integration |
 | `@p2pdotme/sdk/zkkyc` | [ZK KYC](./src/zkkyc/README.md) — Reclaim, Anon Aadhaar, ZK Passport |
 | `@p2pdotme/sdk/country` | [Country & currency config](./src/country/README.md) — payment methods, validators, field configs |
+| `@p2pdotme/sdk/payment-proof` | [Encrypted payment proofs](./src/payment-proof/README.md) for completed SELL/PAY orders — request, status pill, download |
 | `@p2pdotme/sdk/react` | Unified React provider (`SdkProvider`) + hooks |
 
 Circle-selection routing is an internal implementation detail of `placeOrder` — it is **not** exposed as a public subpath.

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@p2pdotme/sdk",
@@ -7,6 +8,7 @@
         "@fingerprintjs/fingerprintjs": "5.1.0",
         "@seontechnologies/seon-javascript-sdk": "6.10.2",
         "neverthrow": "8.2.0",
+        "p2pme-encrypted-payment-proof": "1.2.0",
         "viem": "2.47.6",
         "zod": "4.3.6",
       },
@@ -524,6 +526,8 @@
     "p-map": ["p-map@2.1.0", "", {}, "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="],
 
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
+
+    "p2pme-encrypted-payment-proof": ["p2pme-encrypted-payment-proof@1.2.0", "", {}, "sha512-9XM/5EV8q7ON6pDtWIE3VGEGNAH3urweArwmsIXjVzm8YUyDfToRjS0iDjq+4cURDxyzr1fBlpMQZcIgdqT68A=="],
 
     "package-manager-detector": ["package-manager-detector@0.2.11", "", { "dependencies": { "quansync": "^0.2.7" } }, "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ=="],
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,11 @@
       "types": "./dist/zkkyc.d.ts",
       "import": "./dist/zkkyc.mjs",
       "require": "./dist/zkkyc.cjs"
+    },
+    "./payment-proof": {
+      "types": "./dist/payment-proof.d.ts",
+      "import": "./dist/payment-proof.mjs",
+      "require": "./dist/payment-proof.cjs"
     }
   },
   "typesVersions": {
@@ -91,6 +96,9 @@
       ],
       "zkkyc": [
         "./dist/zkkyc.d.ts"
+      ],
+      "payment-proof": [
+        "./dist/payment-proof.d.ts"
       ]
     }
   },
@@ -123,6 +131,7 @@
     "@fingerprintjs/fingerprintjs": "5.1.0",
     "@seontechnologies/seon-javascript-sdk": "6.10.2",
     "neverthrow": "8.2.0",
+    "p2pme-encrypted-payment-proof": "1.2.0",
     "viem": "2.47.6",
     "zod": "4.3.6"
   },

--- a/src/payment-proof/README.md
+++ b/src/payment-proof/README.md
@@ -1,0 +1,83 @@
+# @p2pdotme/sdk/payment-proof
+
+Client for the P2P.me [encrypted-payment-proof](https://github.com/p2pdotme/encrypted-payment-proof) server. After a **completed SELL/PAY order**, the order creator can request a payment proof; the merchant / circle uploads it and a circle admin signs off. This module lets an integrator surface a proof pill, raise a request, and download an uploaded proof.
+
+BUY orders settle on-chain — they have no proof flow.
+
+Everything returns `ResultAsync` (no thrown exceptions). The wallet signs in **once per session**; the bearer token is cached and reused.
+
+## Usage
+
+```ts
+import { createPaymentProof } from "@p2pdotme/sdk/payment-proof";
+
+const proof = createPaymentProof({
+  apiUrl: PROOF_API_URL,        // base URL of the proof server
+  address: smartAccountAddress, // on-chain identity to claim
+  chainId: 8453,                // must match the server's CHAIN_ID
+  signMessage: (message) => walletClient.signMessage({ message }),
+  storage: sessionStorage,      // optional — persist the token across reloads
+});
+
+// Public config (no wallet prompt) — hide the request control for a disabled currency.
+const config = await proof.getPublicConfig();
+
+// Proof pill: read the request status for a completed SELL/PAY order.
+const status = await proof.getOrderProofRequest({ orderId });
+status.match(
+  (request) => console.log(request?.status ?? "no request"),
+  (error) => console.error(`[${error.code}] ${error.message}`),
+);
+
+// Order creator raises a request.
+await proof.requestProof({ orderId });
+```
+
+## API
+
+### `createPaymentProof(config)`
+
+| Config | Type | Description |
+|--------|------|-------------|
+| `apiUrl` | `string` | Base URL of the encrypted-payment-proof server |
+| `address` | `Address` | On-chain identity to claim (smart-account for user/merchant apps, EOA for ops) |
+| `chainId` | `number` | EIP-155 chain id the wallet is on (must match the server's `CHAIN_ID`) |
+| `signMessage` | `(message: string) => Promise<string>` | EIP-191 `personal_sign`. Called at most once per session |
+| `storage` | `SessionStorageLike?` | Optional bearer-token persistence (e.g. `sessionStorage`). In-memory if omitted |
+| `fetch` | `typeof fetch?` | Override for tests / non-browser runtimes |
+
+### `proof.getPublicConfig()` → `ResultAsync<PublicConfigDto, PaymentProofError>`
+
+Currency denylist + request window. **Unauthenticated** — sends no wallet prompt.
+
+### `proof.getOrderProofRequest({ orderId })` → `ResultAsync<ProofRequestDto | null, PaymentProofError>`
+
+The proof request for one order, or `null` if none exists. Drives the proof pill.
+
+### `proof.requestProof({ orderId, note? })` → `ResultAsync<ProofRequestDto, PaymentProofError>`
+
+Raise a proof request for a completed SELL/PAY order (order creator only). `note` is optional raw bytes.
+
+### `proof.listProofFiles({ requestId })` → `ResultAsync<ProofFileDto[], PaymentProofError>`
+
+A request's proof files (metadata only).
+
+### `proof.downloadProof({ requestId, fileId })` → `ResultAsync<Uint8Array, PaymentProofError>`
+
+Fetch a short-lived token then download the raw file bytes in one call.
+
+### `proof.hasSession()` → `boolean`
+
+Synchronous probe: is there a cached, unexpired session? No network, no signature.
+
+## Errors
+
+```ts
+type PaymentProofErrorCode =
+  | "VALIDATION_ERROR"
+  | "SESSION_ERROR"
+  | "API_ERROR"
+  | "NETWORK_ERROR";
+```
+
+The server's own error code (e.g. `WINDOW_EXPIRED`, `COUNTRY_DISABLED`, `FORBIDDEN`) is carried in `error.context.apiCode`, with the HTTP status in `error.context.status`.

--- a/src/payment-proof/client.ts
+++ b/src/payment-proof/client.ts
@@ -1,0 +1,134 @@
+import { ResultAsync } from "neverthrow";
+import {
+	ApiError,
+	createProofClient,
+	createSessionAuthorization,
+	type ProofFileDto,
+	type ProofRequestDto,
+	type PublicConfigDto,
+} from "p2pme-encrypted-payment-proof";
+import { validate } from "../validation";
+import { PaymentProofError } from "./errors";
+import type { PaymentProofConfig } from "./types";
+import {
+	type OrderProofParams,
+	type ProofFileParams,
+	type ProofRequestIdParams,
+	type RequestProofParams,
+	ZodOrderProofParamsSchema,
+	ZodProofFileParamsSchema,
+	ZodProofRequestIdParamsSchema,
+	ZodRequestProofParamsSchema,
+} from "./validation";
+
+export interface PaymentProof {
+	/**
+	 * Public feature config (currency denylist + request window). Unauthenticated —
+	 * sends NO wallet prompt, so a UI can call it on load to hide the request control
+	 * for a disabled currency. The server enforces both server-side regardless.
+	 */
+	getPublicConfig(): ResultAsync<PublicConfigDto, PaymentProofError>;
+
+	/**
+	 * The proof request for one order, or `null` if none exists. Use its `status`
+	 * (`PENDING` / `FULFILLED` / `APPROVED`) to drive a proof pill on a completed
+	 * SELL/PAY order.
+	 */
+	getOrderProofRequest(
+		params: OrderProofParams,
+	): ResultAsync<ProofRequestDto | null, PaymentProofError>;
+
+	/** Raise a proof request for a completed SELL/PAY order (order creator only). */
+	requestProof(params: RequestProofParams): ResultAsync<ProofRequestDto, PaymentProofError>;
+
+	/** List a request's proof files (metadata only; fetch bytes via `downloadProof`). */
+	listProofFiles(params: ProofRequestIdParams): ResultAsync<ProofFileDto[], PaymentProofError>;
+
+	/** Fetch a token then download the raw proof-file bytes in one call. */
+	downloadProof(params: ProofFileParams): ResultAsync<Uint8Array, PaymentProofError>;
+
+	/**
+	 * Synchronous probe: is there a cached, unexpired session? No network, no
+	 * signature — e.g. to decide whether a read will prompt the wallet.
+	 */
+	hasSession(): boolean;
+}
+
+const toValidationError = (message: string, cause: unknown): PaymentProofError =>
+	new PaymentProofError(message, { code: "VALIDATION_ERROR", cause });
+
+function toError(error: unknown): PaymentProofError {
+	if (error instanceof PaymentProofError) return error;
+	if (error instanceof ApiError) {
+		return new PaymentProofError(error.message, {
+			code: "API_ERROR",
+			cause: error,
+			context: { status: error.status, apiCode: error.code },
+		});
+	}
+	if (error instanceof Error && error.message.includes("mint proof session")) {
+		return new PaymentProofError("Failed to establish a proof session", {
+			code: "SESSION_ERROR",
+			cause: error,
+		});
+	}
+	return new PaymentProofError("Payment-proof request failed", {
+		code: "NETWORK_ERROR",
+		cause: error,
+	});
+}
+
+/**
+ * Creates a Payment Proof SDK instance for the encrypted-payment-proof server. All
+ * methods return `ResultAsync` — no thrown exceptions. The wallet signs in once per
+ * session (via `config.signMessage`); the bearer token is cached and reused.
+ */
+export function createPaymentProof(config: PaymentProofConfig): PaymentProof {
+	const authorization = createSessionAuthorization({
+		baseUrl: config.apiUrl,
+		address: config.address,
+		chainId: config.chainId,
+		signMessage: config.signMessage,
+		storage: config.storage,
+		fetch: config.fetch,
+	});
+
+	const client = createProofClient({
+		baseUrl: config.apiUrl,
+		authorization,
+		fetch: config.fetch,
+	});
+
+	const wrap = <T>(promise: Promise<T>): ResultAsync<T, PaymentProofError> =>
+		ResultAsync.fromPromise(promise, toError);
+
+	return {
+		getPublicConfig: () => wrap(client.getPublicConfig()),
+
+		getOrderProofRequest: (params) =>
+			validate(ZodOrderProofParamsSchema, params, toValidationError).asyncAndThen((p) =>
+				wrap(client.getOrderProofRequests(p.orderId).then((r) => r.request)),
+			),
+
+		requestProof: (params) =>
+			validate(ZodRequestProofParamsSchema, params, toValidationError).asyncAndThen((p) =>
+				wrap(client.requestProof(p.orderId, { note: p.note })),
+			),
+
+		listProofFiles: (params) =>
+			validate(ZodProofRequestIdParamsSchema, params, toValidationError).asyncAndThen((p) =>
+				wrap(client.listProofFiles(p.requestId).then((r) => r.files)),
+			),
+
+		downloadProof: (params) =>
+			validate(ZodProofFileParamsSchema, params, toValidationError).asyncAndThen((p) =>
+				wrap(
+					client
+						.getDownloadToken(p.requestId, p.fileId)
+						.then(({ token }) => client.downloadProof(p.requestId, p.fileId, token)),
+				),
+			),
+
+		hasSession: () => authorization.hasFreshSession(),
+	};
+}

--- a/src/payment-proof/errors.ts
+++ b/src/payment-proof/errors.ts
@@ -1,0 +1,26 @@
+import { SdkError } from "../validation";
+
+export type PaymentProofErrorCode =
+	| "VALIDATION_ERROR"
+	| "SESSION_ERROR"
+	| "API_ERROR"
+	| "NETWORK_ERROR";
+
+/**
+ * Error surfaced by every `@p2pdotme/sdk/payment-proof` method. The proof server's
+ * own error code (e.g. `WINDOW_EXPIRED`, `COUNTRY_DISABLED`, `FORBIDDEN`) is carried
+ * in `context.apiCode`, with the HTTP status in `context.status`.
+ */
+export class PaymentProofError extends SdkError<PaymentProofErrorCode> {
+	constructor(
+		message: string,
+		options: {
+			code: PaymentProofErrorCode;
+			cause?: unknown;
+			context?: Record<string, unknown>;
+		},
+	) {
+		super(message, options);
+		this.name = "PaymentProofError";
+	}
+}

--- a/src/payment-proof/index.ts
+++ b/src/payment-proof/index.ts
@@ -1,0 +1,24 @@
+// ── Main entry point ────────────────────────────────────────────────────
+
+export { createPaymentProof, type PaymentProof } from "./client";
+
+// ── Types ───────────────────────────────────────────────────────────────
+
+export type { ProofStatus } from "p2pme-encrypted-payment-proof";
+export type {
+	PaymentProofConfig,
+	ProofFileDto,
+	ProofRequestDto,
+	PublicConfigDto,
+	SessionStorageLike,
+} from "./types";
+export type {
+	OrderProofParams,
+	ProofFileParams,
+	ProofRequestIdParams,
+	RequestProofParams,
+} from "./validation";
+
+// ── Errors ──────────────────────────────────────────────────────────────
+
+export { PaymentProofError, type PaymentProofErrorCode } from "./errors";

--- a/src/payment-proof/types.ts
+++ b/src/payment-proof/types.ts
@@ -1,0 +1,37 @@
+import type {
+	ProofFileDto,
+	ProofRequestDto,
+	PublicConfigDto,
+	SessionStorageLike,
+} from "p2pme-encrypted-payment-proof";
+import type { Address } from "viem";
+
+// ── Re-exported wire DTOs (for consumer typing) ─────────────────────────
+
+export type { ProofFileDto, ProofRequestDto, PublicConfigDto, SessionStorageLike };
+
+// ── Client config ───────────────────────────────────────────────────────
+
+export interface PaymentProofConfig {
+	/** Base URL of the encrypted-payment-proof server (e.g. `https://proof.p2p.me`). */
+	readonly apiUrl: string;
+	/**
+	 * On-chain identity to claim — the smart-account address for the user/merchant
+	 * apps, the EOA for ops. The server's role checks are evaluated against it.
+	 */
+	readonly address: Address;
+	/** EIP-155 chain id the wallet is on (must match the server's `CHAIN_ID`). */
+	readonly chainId: number;
+	/**
+	 * EIP-191 `personal_sign` of the sign-in message. Called at most once per session
+	 * — the minted bearer token is reused until it nears expiry.
+	 */
+	readonly signMessage: (message: string) => Promise<string>;
+	/**
+	 * Optional bearer-token persistence (e.g. `sessionStorage`) so a session survives
+	 * a page reload. In-memory only when omitted.
+	 */
+	readonly storage?: SessionStorageLike;
+	/** Override for tests / non-browser runtimes. */
+	readonly fetch?: typeof fetch;
+}

--- a/src/payment-proof/validation.ts
+++ b/src/payment-proof/validation.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+/** `{ orderId }` — the order to read/raise a proof request for. */
+export const ZodOrderProofParamsSchema = z.object({
+	orderId: z.string().min(1),
+});
+
+export type OrderProofParams = z.infer<typeof ZodOrderProofParamsSchema>;
+
+/** `{ orderId, note? }` — raise a proof request; `note` is optional raw bytes. */
+export const ZodRequestProofParamsSchema = z.object({
+	orderId: z.string().min(1),
+	note: z.instanceof(Uint8Array).optional(),
+});
+
+export type RequestProofParams = z.infer<typeof ZodRequestProofParamsSchema>;
+
+/** `{ requestId }` — a proof request whose files to list. */
+export const ZodProofRequestIdParamsSchema = z.object({
+	requestId: z.string().min(1),
+});
+
+export type ProofRequestIdParams = z.infer<typeof ZodProofRequestIdParamsSchema>;
+
+/** `{ requestId, fileId }` — a single proof file to download. */
+export const ZodProofFileParamsSchema = z.object({
+	requestId: z.string().min(1),
+	fileId: z.string().min(1),
+});
+
+export type ProofFileParams = z.infer<typeof ZodProofFileParamsSchema>;

--- a/test/payment-proof/client.test.ts
+++ b/test/payment-proof/client.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPaymentProof } from "../../src/payment-proof";
+
+const API = "https://proof.example.com";
+const ADDRESS = "0x1111111111111111111111111111111111111111";
+
+interface Route {
+	status: number;
+	json: unknown;
+}
+
+/** Minimal fetch stub keyed by `METHOD path`. */
+function stubFetch(routes: Record<string, Route>) {
+	return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = new URL(String(input));
+		const method = init?.method ?? "GET";
+		const key = `${method} ${url.pathname}`;
+		const route = routes[key];
+		if (!route) throw new TypeError(`no stub for ${key}`);
+		return {
+			ok: route.status >= 200 && route.status < 300,
+			status: route.status,
+			json: async () => route.json,
+			arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+		} as unknown as Response;
+	});
+}
+
+function makeSdk(fetchStub: ReturnType<typeof stubFetch>) {
+	return createPaymentProof({
+		apiUrl: API,
+		address: ADDRESS,
+		chainId: 8453,
+		signMessage: async () => "0xsig",
+		fetch: fetchStub as unknown as typeof fetch,
+	});
+}
+
+const SESSION_ROUTE: Record<string, Route> = {
+	"POST /auth/session": {
+		status: 200,
+		json: { token: "tok", expiresAt: Date.now() + 60_000, address: ADDRESS },
+	},
+};
+
+describe("createPaymentProof", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("getPublicConfig reads without signing in", async () => {
+		const signMessage = vi.fn(async () => "0xsig");
+		const sdk = createPaymentProof({
+			apiUrl: API,
+			address: ADDRESS,
+			chainId: 8453,
+			signMessage,
+			fetch: stubFetch({
+				"GET /public/config": {
+					status: 200,
+					json: { ignoredCurrencies: ["INR"], requestWindowHours: 48 },
+				},
+			}) as unknown as typeof fetch,
+		});
+
+		const res = await sdk.getPublicConfig();
+		expect(res.isOk()).toBe(true);
+		expect(res._unsafeUnwrap().ignoredCurrencies).toEqual(["INR"]);
+		expect(signMessage).not.toHaveBeenCalled();
+	});
+
+	it("getOrderProofRequest returns the request (null when none)", async () => {
+		const sdk = makeSdk(
+			stubFetch({
+				...SESSION_ROUTE,
+				"GET /orders/42/proof-requests": {
+					status: 200,
+					json: { request: { id: "r1", orderId: "42", status: "PENDING" } },
+				},
+			}),
+		);
+
+		const res = await sdk.getOrderProofRequest({ orderId: "42" });
+		expect(res.isOk()).toBe(true);
+		expect(res._unsafeUnwrap()?.status).toBe("PENDING");
+	});
+
+	it("requestProof surfaces server error codes as API_ERROR + apiCode", async () => {
+		const sdk = makeSdk(
+			stubFetch({
+				...SESSION_ROUTE,
+				"POST /orders/42/proof-requests": {
+					status: 409,
+					json: { error: "WINDOW_EXPIRED" },
+				},
+			}),
+		);
+
+		const res = await sdk.requestProof({ orderId: "42" });
+		expect(res.isErr()).toBe(true);
+		const error = res._unsafeUnwrapErr();
+		expect(error.code).toBe("API_ERROR");
+		expect(error.context?.apiCode).toBe("WINDOW_EXPIRED");
+		expect(error.context?.status).toBe(409);
+	});
+
+	it("rejects empty orderId with VALIDATION_ERROR before any fetch", async () => {
+		const fetchStub = stubFetch({});
+		const sdk = makeSdk(fetchStub);
+
+		const res = await sdk.getOrderProofRequest({ orderId: "" });
+		expect(res.isErr()).toBe(true);
+		expect(res._unsafeUnwrapErr().code).toBe("VALIDATION_ERROR");
+		expect(fetchStub).not.toHaveBeenCalled();
+	});
+
+	it("downloadProof fetches a token then the bytes", async () => {
+		const sdk = makeSdk(
+			stubFetch({
+				...SESSION_ROUTE,
+				"GET /proof-requests/r1/files/f1/token": {
+					status: 200,
+					json: { token: "dl", expiresAt: Date.now() + 60_000 },
+				},
+				"GET /proof-requests/r1/files/f1": { status: 200, json: {} },
+			}),
+		);
+
+		const res = await sdk.downloadProof({ requestId: "r1", fileId: "f1" });
+		expect(res.isOk()).toBe(true);
+		expect(res._unsafeUnwrap()).toEqual(new Uint8Array([1, 2, 3]));
+	});
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -102,4 +102,13 @@ export default defineConfig([
       return { js: format === "cjs" ? ".cjs" : ".mjs" };
     },
   },
+  {
+    entry: { "payment-proof": "src/payment-proof/index.ts" },
+    format: ["cjs", "esm"],
+    dts: true,
+    sourcemap: true,
+    outExtension({ format }) {
+      return { js: format === "cjs" ? ".cjs" : ".mjs" };
+    },
+  },
 ]);


### PR DESCRIPTION
## Summary
Adds a new subpath module **`@p2pdotme/sdk/payment-proof`** — a client for the [encrypted-payment-proof](https://github.com/p2pdotme/encrypted-payment-proof) server, so B2B integrators can offer payment proofs on completed **SELL/PAY** orders (BUY settles on-chain, no proof flow).

Thin `ResultAsync` wrapper over the published `p2pme-encrypted-payment-proof@1.2.0` client, following the SDK's conventions: factory config, no env reads, Zod validation at boundaries, no thrown exceptions.

### Surface
| Method | Purpose |
|--------|---------|
| `getPublicConfig()` | Currency denylist + request window (unauthenticated — no wallet prompt) |
| `getOrderProofRequest({ orderId })` | Proof-request status for one order → drives a proof pill (`null` when none) |
| `requestProof({ orderId, note? })` | Order creator raises a request |
| `listProofFiles({ requestId })` | A request's files (metadata) |
| `downloadProof({ requestId, fileId })` | Token + raw bytes in one call |
| `hasSession()` | Sync probe: cached, unexpired session? (no network/signature) |

Wallet signs in **once per session** via `config.signMessage`; the bearer token is cached (optionally persisted via `storage`). Server error codes (`WINDOW_EXPIRED`, `COUNTRY_DISABLED`, `FORBIDDEN`, …) surface in `error.context.apiCode`.

### Wiring
- `package.json` — `./payment-proof` export + `typesVersions` + `p2pme-encrypted-payment-proof` dep
- `tsup.config.ts` — new entry point
- README modules table + `CLAUDE.md` architecture/deps + per-module README
- Changeset (`minor`)

## Notes
Depends on the proof server's `CORS_ORIGINS=*` opt-in ([encrypted-payment-proof#24](https://github.com/p2pdotme/encrypted-payment-proof/pull/24)) so integrators on arbitrary domains can call the API.

## Test plan
- [x] `bun run build` — emits `dist/payment-proof.{mjs,cjs,d.ts}`
- [x] `bun run typecheck` — clean
- [x] `bun run lint` (new module) — clean
- [x] `bun run test test/payment-proof` — 5/5 pass (fake-fetch: config read w/o sign-in, order status, API_ERROR+apiCode mapping, validation short-circuit, token+download)