### PR TITLE
feat(fraud-engine): bind subject address into the signed message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p2pdotme/sdk",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "P2P.me SDK",
   "license": "MIT",
   "type": "module",

--- a/src/fraud-engine/signing.ts
+++ b/src/fraud-engine/signing.ts
@@ -5,14 +5,22 @@ export async function getSignedHeaders(
 	signer: FraudEngineSigner,
 	action: "activity-log" | "link-order" | "fingerprint-log",
 ): Promise<Record<string, string>> {
-	// The EIP-191 signed message is bound to the address of the key that
-	// actually produces the signature (the admin EOA for AA smart wallets),
-	// not to the tracked subject address. For plain EOA signers where no
-	// separate `signerAddress` is provided, this falls back to `signer.address`
-	// and behaviour is identical to the single-address case.
+	// The signed message binds BOTH addresses: the key that produces the
+	// signature (the admin EOA for AA smart wallets) and the subject the
+	// request acts for (the smart account). Binding the subject stops a
+	// signature captured for one account being replayed against another
+	// inside the backend's freshness window.
+	//
+	// This is not by itself an authorisation control — the backend decides
+	// entitlement by checking on-chain that the signer is an admin of the
+	// subject account. See fraud-engine `core/wallet_auth.py`.
+	//
+	// For plain EOA signers where no separate `signerAddress` is provided,
+	// both values collapse to `signer.address`.
 	const signingAddress = (signer.signerAddress ?? signer.address).toLowerCase();
+	const subjectAddress = signer.address.toLowerCase();
 	const timestamp = Math.floor(Date.now() / 1000).toString();
-	const message = `${action}:${signingAddress}:${timestamp}`;
+	const message = `${action}:${signingAddress}:${subjectAddress}:${timestamp}`;
 
 	try {
 		const signature = await signer.signMessage(message);


### PR DESCRIPTION
Client half of the fraud-engine wallet-auth fix — pairs with **p2pdotme/fraud-engine#41**.

## What changed

`getSignedHeaders` signed `{action}:{signer}:{ts}`. For AA smart wallets the signer is the **admin EOA** while the tracked subject is the **smart account**, so the message never said which account the request was for — a signature captured for one account was replayable against another inside the backend's 5-minute freshness window.

Now: `{action}:{signer}:{subject}:{ts}`, where `subject` is `signer.address` — the same value already sent as `user_address` in every request body, so the two can't drift.

```diff
-const message = `${action}:${signingAddress}:${timestamp}`;
+const subjectAddress = signer.address.toLowerCase();
+const message = `${action}:${signingAddress}:${subjectAddress}:${timestamp}`;
```

## No consumer code change needed

Both addresses were already on `FraudEngineSigner` (`address` = subject, `signerAddress` = admin EOA), so this is entirely internal to `getSignedHeaders`. **Consumers only need the version bump** — `user-app-client`, `coins.me-2.0` and `widgets` get it for free. For plain EOA signers both values collapse to `signer.address`, unchanged from today.

Version: `1.2.6` → `1.2.7`.

## What this does and does not do

Binding the subject is **not** an authorisation control on its own — an attacker can sign a message naming any subject and it will verify. Entitlement is decided backend-side, which checks on-chain that the signer is an admin of the subject smart account. This change is **defence in depth** against cross-subject replay. See fraud-engine#41 for the actual fix.

## Safe to ship independently

The backend accepts **both** the old and new message formats during rollout, so there is no ordering constraint against any other client and no coordination window. Merge and release whenever.

## Verified

- `tsc --noEmit` — no errors in `src/`. (Pre-existing `example/` errors about `@p2pdotme/sdk/*` subpath imports are unrelated; they need a built `dist/`.)
- Confirmed `user_address` in `client.ts` is `signer.address` at all three call sites, so the signed subject always matches the body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)