### PR TITLE
feat(fraud-engine): bind subject address into the signed message (#52)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p2pdotme/sdk",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "P2P.me SDK",
   "license": "MIT",
   "type": "module",

--- a/src/fraud-engine/signing.ts
+++ b/src/fraud-engine/signing.ts
@@ -5,14 +5,22 @@ export async function getSignedHeaders(
 	signer: FraudEngineSigner,
 	action: "activity-log" | "link-order" | "fingerprint-log",
 ): Promise<Record<string, string>> {
-	// The EIP-191 signed message is bound to the address of the key that
-	// actually produces the signature (the admin EOA for AA smart wallets),
-	// not to the tracked subject address. For plain EOA signers where no
-	// separate `signerAddress` is provided, this falls back to `signer.address`
-	// and behaviour is identical to the single-address case.
+	// The signed message binds BOTH addresses: the key that produces the
+	// signature (the admin EOA for AA smart wallets) and the subject the
+	// request acts for (the smart account). Binding the subject stops a
+	// signature captured for one account being replayed against another
+	// inside the backend's freshness window.
+	//
+	// This is not by itself an authorisation control — the backend decides
+	// entitlement by checking on-chain that the signer is an admin of the
+	// subject account. See fraud-engine `core/wallet_auth.py`.
+	//
+	// For plain EOA signers where no separate `signerAddress` is provided,
+	// both values collapse to `signer.address`.
 	const signingAddress = (signer.signerAddress ?? signer.address).toLowerCase();
+	const subjectAddress = signer.address.toLowerCase();
 	const timestamp = Math.floor(Date.now() / 1000).toString();
-	const message = `${action}:${signingAddress}:${timestamp}`;
+	const message = `${action}:${signingAddress}:${subjectAddress}:${timestamp}`;
 
 	try {
 		const signature = await signer.signMessage(message);


### PR DESCRIPTION
* feat(fraud-engine): bind subject address into the signed message

The signed message committed only to the signing key's own address: `{action}:{signer}:{ts}`. For AA smart wallets the signer is the admin EOA while the tracked subject is the smart account, so the message said nothing about which account the request was for. A signature captured for one account was replayable against another inside the backend's 5-minute freshness window.

Both addresses are now bound: `{action}:{signer}:{subject}:{ts}`, where subject is `signer.address` — the same value already sent as `user_address` in every request body, so the two cannot drift.

No consumer code change is required. Both addresses were already present on FraudEngineSigner, so this is internal to getSignedHeaders; consumers only need the version bump. For plain EOA signers both values collapse to `signer.address` as before.

To be clear about what this does and does not do: binding the subject is NOT an authorisation control on its own, because an attacker can sign a message naming any subject. Entitlement is decided backend-side, which verifies on-chain that the signer is an admin of the subject smart account (p2pdotme/fraud-engine#41). This change is defence in depth against cross-subject replay.

Backend accepts both the old and new message formats during rollout, so this can ship independently of any other client.



* chore: release as 1.2.8, not 1.2.7

1.2.7 was already published to npm from a different change and does not contain the subject binding -- all four dist bundles still emit `${action}:${signingAddress}:${timestamp}` and none mention subjectAddress. Publishing 1.2.7 again would be rejected by npm, and any client pinning 1.2.7 would silently get an SDK without the binding. Release this as 1.2.8 instead.



---------