### PR TITLE
chore(release): bump version to 1.2.11 so CUP/PHP support can be published

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p2pdotme/sdk",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "P2P.me SDK",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Why

`dev` (and `main`) already contain `CUP` and `PHP` in the `CURRENCY` map (from the Cuba/Transfermóvil work), but the latest version on npm — `1.2.10` — was published before those codes landed, so its published types are missing both. This breaks the `user-app-client` production build, which references `CURRENCY.CUP` / `CURRENCY.PHP`:

```
src/pages/sell/preview/sell-addresses-drawer/address-form-view.tsx(160,58): error TS2339: Property 'CUP' does not exist on type '{ readonly IDR: "IDR"; ... }'.
```

`package.json` still says `1.2.10`, so `changeset publish` has nothing new to publish.

## What

- Bump `version` from `1.2.10` to `1.2.11` (no source changes — the CUP/PHP code is already merged). Branch is rebased onto `dev`.

## Verified

- `bun run build` succeeds and the built `dist/country.d.ts` includes `CUP` and `PHP`.
- `bun run typecheck` passes.
- `bun run test`: 433 passed, 17 skipped; the only failing file is `test/qr-parsers/brl.test.ts`, which requires a local `PIX_PROXY_URL` env var and is unrelated.

## After merge

A maintainer needs to run `bun run release` (or otherwise publish `1.2.11` to npm). Then `user-app-client` can bump its `@p2pdotme/sdk` pin to `1.2.11` to fix its build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5xTVjaiqvtiuSWoHDX1H8