### PR TITLE
fix(qr-parsers): harden EMVCo amount and CRC parsing

### DIFF
--- a/.changeset/harden-qr-amount-crc.md
+++ b/.changeset/harden-qr-amount-crc.md
@@ -1,0 +1,17 @@
+---
+"@p2pdotme/sdk": patch
+---
+
+qr-parsers: fix two correctness bugs in EMVCo QR parsing
+
+- `verifyCRC16` located the CRC tag with `lastIndexOf("6304")`, which matched the
+  CRC *value* instead of the tag whenever a valid QR's checksum was exactly
+  `6304` (payload ending `...63046304`), falsely rejecting the code. The tag is
+  now located positionally at `length - 8`. Affects PIX, MercadoPago, NGN and QRPh.
+- `parseAmount` used `parseFloat`, which silently accepted a valid numeric prefix
+  with trailing garbage (`"12abc"` → `12`), plus `"Infinity"` and exponent forms.
+  It also never validated `sellPrice`, so a `0` or negative price produced an
+  `Infinity`/negative `usdc`. It now requires a whole-string finite positive
+  decimal and a finite positive `sellPrice`, returning `null` otherwise.
+
+Added dedicated unit tests for both utilities, including regression cases.

--- a/src/qr-parsers/utils/amount.ts
+++ b/src/qr-parsers/utils/amount.ts
@@ -1,15 +1,24 @@
+/** Plain decimal, EMVCo-style: digits with an optional single fractional part. */
+const DECIMAL_AMOUNT = /^\d+(\.\d+)?$/;
+
 /**
  * Parse a fiat amount string and convert to usdc using sellPrice.
- * Returns null if the amount is not parseable or <= 0.
+ * Returns null unless the whole string is a finite, positive decimal amount and
+ * sellPrice is a finite positive number. Rejects trailing garbage ("12abc"),
+ * exponent/Infinity/NaN forms that parseFloat would otherwise accept, and a
+ * zero/negative sellPrice that would produce an Infinite or negative usdc value.
  */
 export function parseAmount(
 	amountStr: string,
 	sellPrice: number,
 ): { usdc: number; fiat: number } | null {
-	if (!amountStr || amountStr.trim() === "") return null;
+	if (!amountStr) return null;
+	const trimmed = amountStr.trim();
+	if (!DECIMAL_AMOUNT.test(trimmed)) return null;
 
-	const fiat = parseFloat(amountStr.trim());
-	if (Number.isNaN(fiat) || fiat <= 0) return null;
+	const fiat = Number(trimmed);
+	if (!Number.isFinite(fiat) || fiat <= 0) return null;
+	if (!Number.isFinite(sellPrice) || sellPrice <= 0) return null;
 
 	return { usdc: fiat / sellPrice, fiat };
 }

--- a/src/qr-parsers/utils/crc16.ts
+++ b/src/qr-parsers/utils/crc16.ts
@@ -34,8 +34,12 @@ export function verifyCRC16(qrData: string): { valid: boolean; error?: string } 
 		return { valid: false, error: "QR data too short for CRC verification" };
 	}
 
-	const crcTagIndex = qrData.lastIndexOf("6304");
-	if (crcTagIndex === -1 || crcTagIndex + 8 !== qrData.length) {
+	// The CRC tag is always the final data object: "63" (tag) + "04" (length) +
+	// 4 hex CRC digits. It must sit at a fixed position (length - 8). Locating it
+	// positionally — rather than with lastIndexOf("6304") — avoids a false match
+	// when the CRC value itself is "6304" (payload ends "...63046304").
+	const crcTagIndex = qrData.length - 8;
+	if (qrData.substring(crcTagIndex, crcTagIndex + 4) !== "6304") {
 		return { valid: false, error: "Missing or misplaced CRC tag (6304)" };
 	}
 

--- a/test/qr-parsers/amount.test.ts
+++ b/test/qr-parsers/amount.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { parseAmount } from "../../src/qr-parsers/utils/amount";
+
+describe("parseAmount", () => {
+	it("parses a plain decimal amount and converts to usdc", () => {
+		expect(parseAmount("100", 2)).toEqual({ fiat: 100, usdc: 50 });
+		expect(parseAmount("10.50", 5)).toEqual({ fiat: 10.5, usdc: 2.1 });
+	});
+
+	it("trims surrounding whitespace", () => {
+		expect(parseAmount("  25  ", 5)).toEqual({ fiat: 25, usdc: 5 });
+	});
+
+	it("returns null for empty or blank input", () => {
+		expect(parseAmount("", 5)).toBeNull();
+		expect(parseAmount("   ", 5)).toBeNull();
+	});
+
+	it("returns null for non-positive amounts", () => {
+		expect(parseAmount("0", 5)).toBeNull();
+		expect(parseAmount("-10", 5)).toBeNull();
+	});
+
+	// Regression: parseFloat used to accept a valid numeric prefix and ignore the
+	// rest, letting malformed QR amount fields through as a bogus "success".
+	it("rejects trailing garbage", () => {
+		expect(parseAmount("12abc", 5)).toBeNull();
+		expect(parseAmount("10 20", 5)).toBeNull();
+	});
+
+	// Regression: parseFloat accepted "Infinity" and exponent notation, producing
+	// non-finite or unexpected amounts from a QR field.
+	it("rejects Infinity, NaN, and exponent notation", () => {
+		expect(parseAmount("Infinity", 5)).toBeNull();
+		expect(parseAmount("NaN", 5)).toBeNull();
+		expect(parseAmount("1e3", 5)).toBeNull();
+	});
+
+	// Regression: an unvalidated sellPrice of 0 produced Infinity usdc, and a
+	// negative sellPrice produced a negative usdc amount.
+	it("rejects a zero, negative, or non-finite sellPrice", () => {
+		expect(parseAmount("100", 0)).toBeNull();
+		expect(parseAmount("100", -2)).toBeNull();
+		expect(parseAmount("100", Number.NaN)).toBeNull();
+		expect(parseAmount("100", Number.POSITIVE_INFINITY)).toBeNull();
+	});
+});

--- a/test/qr-parsers/crc16.test.ts
+++ b/test/qr-parsers/crc16.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { calculateCRC16, verifyCRC16 } from "../../src/qr-parsers/utils/crc16";
+
+describe("calculateCRC16", () => {
+	// EMVCo spec reference payload (SGQR test vector).
+	it("matches the EMVCo reference vector", () => {
+		const payload =
+			"00020101021229300012D156000000000510A93FO3230Q31280012D15600000001030812345678520441115802CN5914BEST TRANSPORT6007BEIJING64200002ZH0104最佳运输0202北京540523.7253031565502016233030412340603***0708A60086670902ME91320016A0112233449988770708123456786304";
+		expect(calculateCRC16(payload.replace(/6304$/, ""))).toBe("A13A");
+	});
+
+	it("zero-pads the checksum to 4 hex digits", () => {
+		const crc = calculateCRC16("000201");
+		expect(crc).toMatch(/^[0-9A-F]{4}$/);
+	});
+});
+
+describe("verifyCRC16", () => {
+	it("accepts a QR whose checksum matches", () => {
+		const inner = "0002015802CN";
+		const qr = `${inner}6304${calculateCRC16(inner)}`;
+		expect(verifyCRC16(qr)).toEqual({ valid: true });
+	});
+
+	// Regression: when the computed CRC is literally "6304", the payload ends
+	// "...63046304". Locating the tag with lastIndexOf("6304") matched the value
+	// and falsely reported a misplaced tag. It must be located positionally.
+	it("accepts a valid QR whose checksum is exactly 6304", () => {
+		const inner = "000201041162";
+		expect(calculateCRC16(inner)).toBe("6304");
+		const qr = `${inner}6304${calculateCRC16(inner)}`; // "...63046304"
+		expect(verifyCRC16(qr)).toEqual({ valid: true });
+	});
+
+	it("rejects a QR with a corrupted checksum", () => {
+		const inner = "0002015802CN";
+		const qr = `${inner}6304${calculateCRC16(inner)}`;
+		const tampered = `${qr.slice(0, -1)}${qr.at(-1) === "0" ? "1" : "0"}`;
+		const result = verifyCRC16(tampered);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("CRC mismatch");
+	});
+
+	it("rejects a string too short to hold a CRC tag", () => {
+		expect(verifyCRC16("6304").valid).toBe(false);
+	});
+
+	it("rejects when the final data object is not the CRC tag", () => {
+		// Ends with a well-formed 8-char suffix, but the tag is "5904" not "6304".
+		const result = verifyCRC16("00020159041234");
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("Missing or misplaced CRC tag");
+	});
+
+	it("rejects a non-hex CRC value", () => {
+		const result = verifyCRC16("0002016304ZZZZ");
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("Invalid CRC hex format");
+	});
+});


### PR DESCRIPTION
## Summary

Fixes two genuine, empirically-reproduced correctness bugs in the QR parser utilities that back the **PIX, MercadoPago, NGN and QRPh** parsers. Both are pure-logic defects in `src/qr-parsers/utils/` that let malformed input through or reject valid input. Adds dedicated unit tests for both utilities (previously covered only indirectly through the per-currency parsers).

## Bug 1 — `verifyCRC16` falsely rejects a valid QR whose checksum is `6304`

`verifyCRC16` located the CRC tag with `qrData.lastIndexOf("6304")`. The EMVCo CRC tag is always the final data object — `"63"` (tag) + `"04"` (length) + 4 hex digits — at a fixed offset of `length - 8`. When the computed CRC value is itself `6304`, the payload ends `...6304` `6304`, so `lastIndexOf` matches the **value** rather than the **tag**, and the `crcTagIndex + 8 === length` check fails, so the QR is wrongly reported as "misplaced CRC tag". Roughly 1 in 65,536 otherwise-valid QRs is affected.

Reproduction (inner payload `000201041162` has CRC `6304`):

```
verifyCRC16("00020104116263046304") // was { valid: false }, now { valid: true }
```

Fix: locate the tag positionally at `length - 8` and assert it equals `"6304"`.

## Bug 2 — `parseAmount` accepts malformed amounts and an invalid `sellPrice`

`parseAmount` used `parseFloat`, which parses a valid numeric prefix and ignores trailing garbage, and also accepts `"Infinity"` / exponent notation. It never validated `sellPrice`, so a `0` or negative price produced an `Infinity`/negative `usdc` that flows into downstream order math.

```
parseAmount("12abc", 5)    // was { fiat: 12,  usdc: 2.4 }
parseAmount("Infinity", 5) // was { fiat: Infinity, usdc: Infinity }
parseAmount("100", 0)      // was { fiat: 100, usdc: Infinity }
parseAmount("100", -2)     // was { fiat: 100, usdc: -50 }
```

Fix: require the **whole** string to be a finite positive decimal (`/^\d+(\.\d+)?$/` + `Number.isFinite`), and require a finite positive `sellPrice`; return `null` otherwise. The `null` contract is unchanged, so no parser call sites need edits.

## Tests

- `test/qr-parsers/crc16.test.ts` — EMVCo `A13A` reference vector, happy path, the `6304`-checksum regression, corrupted-CRC, non-hex, too-short, and wrong-final-tag cases.
- `test/qr-parsers/amount.test.ts` — decimals, whitespace, non-positive, trailing garbage, `Infinity`/`NaN`/exponent, and zero/negative/non-finite `sellPrice`.

```
bunx vitest run test/qr-parsers   # 129 passed (+ new util suites); pre-existing PIX_PROXY_URL env test unaffected
bun run typecheck && bun run build && bun run lint  # clean
```

Includes a patch changeset.
