### PR TITLE
fix(qr-parsers): verify EMVCo CRC-16 on QRIS (IDR) and Yape/Plin (PEN)

### DIFF
--- a/.changeset/harden-qr-amount-crc.md
+++ b/.changeset/harden-qr-amount-crc.md
@@ -1,0 +1,17 @@
+---
+"@p2pdotme/sdk": patch
+---
+
+qr-parsers: fix two correctness bugs in EMVCo QR parsing
+
+- `verifyCRC16` located the CRC tag with `lastIndexOf("6304")`, which matched the
+  CRC *value* instead of the tag whenever a valid QR's checksum was exactly
+  `6304` (payload ending `...63046304`), falsely rejecting the code. The tag is
+  now located positionally at `length - 8`. Affects PIX, MercadoPago, NGN and QRPh.
+- `parseAmount` used `parseFloat`, which silently accepted a valid numeric prefix
+  with trailing garbage (`"12abc"` → `12`), plus `"Infinity"` and exponent forms.
+  It also never validated `sellPrice`, so a `0` or negative price produced an
+  `Infinity`/negative `usdc`. It now requires a whole-string finite positive
+  decimal and a finite positive `sellPrice`, returning `null` otherwise.
+
+Added dedicated unit tests for both utilities, including regression cases.

--- a/.changeset/verify-crc-idr-pen.md
+++ b/.changeset/verify-crc-idr-pen.md
@@ -1,0 +1,19 @@
+---
+"@p2pdotme/sdk": patch
+---
+
+qr-parsers: verify the EMVCo CRC-16 checksum on QRIS (IDR) and Yape/Plin (PEN)
+
+`parseQRIS` and `parsePeru` extracted the amount and merchant fields from the
+EMVCo payload but never validated the mandatory CRC-16 checksum (tag 63) that
+every QRIS and Yape/Plin QR carries — unlike their sibling parsers (QR Ph, PIX,
+MercadoPago, NGN), which already reject on checksum mismatch. A corrupted scan
+or a tampered payload (altered amount or merchant) was therefore accepted as
+valid, and the resulting payment data was trusted downstream.
+
+Both parsers now call `verifyCRC16` and return `INVALID_QR` when the checksum is
+missing or does not match, bringing them in line with the other EMVCo parsers.
+`parseQRIS` also gains the JSDoc required by the repo's commenting rules.
+
+Added regression tests covering valid checksums, a missing CRC tag, and
+tampered-payload rejection for both currencies.

--- a/src/qr-parsers/parsers/idr.ts
+++ b/src/qr-parsers/parsers/idr.ts
@@ -1,16 +1,29 @@
 import type { ParsedQR, ParseResult } from "../types";
 import { failure, success } from "../types";
 import { parseAmount } from "../utils/amount";
+import { verifyCRC16 } from "../utils/crc16";
 import { extractTags } from "../utils/tlv";
 
 const QRIS_TAGS = { AMOUNT: "54", MERCHANT_NAME: "59" } as const;
 
+/**
+ * Parses an Indonesian QRIS EMVCo QR. Verifies the mandatory CRC-16 checksum
+ * (tag 63) before trusting any field, then returns the merchant name (tag 59)
+ * as `paymentAddress`. Static QRs carry no amount; when tag 54 is present it is
+ * converted to usdc via `sellPrice`.
+ */
 export function parseQRIS(qrData: string, sellPrice: number): ParseResult {
 	if (!qrData || typeof qrData !== "string" || qrData.trim().length === 0) {
 		return failure("INVALID_QR", "QR data is empty or invalid");
 	}
 
 	const trimmed = qrData.trim();
+
+	const crc = verifyCRC16(trimmed);
+	if (!crc.valid) {
+		return failure("INVALID_QR", crc.error ?? "Invalid QRIS checksum");
+	}
+
 	const tags = extractTags(trimmed, [QRIS_TAGS.AMOUNT, QRIS_TAGS.MERCHANT_NAME]);
 
 	const merchantName = tags[QRIS_TAGS.MERCHANT_NAME];

--- a/src/qr-parsers/parsers/pen.ts
+++ b/src/qr-parsers/parsers/pen.ts
@@ -1,15 +1,17 @@
 import type { ParsedQR, ParseResult } from "../types";
 import { failure, success } from "../types";
 import { parseAmount } from "../utils/amount";
+import { verifyCRC16 } from "../utils/crc16";
 import { extractTags } from "../utils/tlv";
 
 const PEN_TAGS = { AMOUNT: "54", CURRENCY: "53", COUNTRY: "58" } as const;
 
 /**
  * Parses a Peruvian Yape/Plin EMVCo QR. Validates it is a genuine Peru QR
- * (country tag 58 `PE`, currency tag 53 `604`) and returns the raw payload verbatim
- * as `paymentAddress` so the buyer app can re-render the exact QR. Static QRs carry
- * no amount; when tag 54 is present it is converted to usdc via `sellPrice`.
+ * (country tag 58 `PE`, currency tag 53 `604`, valid CRC) and returns the raw
+ * payload verbatim as `paymentAddress` so the buyer app can re-render the exact
+ * QR. Static QRs carry no amount; when tag 54 is present it is converted to usdc
+ * via `sellPrice`.
  */
 export function parsePeru(qrData: string, sellPrice: number): ParseResult {
 	if (!qrData || typeof qrData !== "string" || qrData.trim().length === 0) {
@@ -21,6 +23,11 @@ export function parsePeru(qrData: string, sellPrice: number): ParseResult {
 
 	if (tags[PEN_TAGS.COUNTRY] !== "PE" || tags[PEN_TAGS.CURRENCY] !== "604") {
 		return failure("INVALID_QR", "Not a valid Peru Yape/Plin QR");
+	}
+
+	const crc = verifyCRC16(trimmed);
+	if (!crc.valid) {
+		return failure("INVALID_QR", crc.error ?? "Invalid Peru QR checksum");
 	}
 
 	const result: ParsedQR = { paymentAddress: trimmed };

--- a/src/qr-parsers/utils/amount.ts
+++ b/src/qr-parsers/utils/amount.ts
@@ -1,15 +1,24 @@
+/** Plain decimal, EMVCo-style: digits with an optional single fractional part. */
+const DECIMAL_AMOUNT = /^\d+(\.\d+)?$/;
+
 /**
  * Parse a fiat amount string and convert to usdc using sellPrice.
- * Returns null if the amount is not parseable or <= 0.
+ * Returns null unless the whole string is a finite, positive decimal amount and
+ * sellPrice is a finite positive number. Rejects trailing garbage ("12abc"),
+ * exponent/Infinity/NaN forms that parseFloat would otherwise accept, and a
+ * zero/negative sellPrice that would produce an Infinite or negative usdc value.
  */
 export function parseAmount(
 	amountStr: string,
 	sellPrice: number,
 ): { usdc: number; fiat: number } | null {
-	if (!amountStr || amountStr.trim() === "") return null;
+	if (!amountStr) return null;
+	const trimmed = amountStr.trim();
+	if (!DECIMAL_AMOUNT.test(trimmed)) return null;
 
-	const fiat = parseFloat(amountStr.trim());
-	if (Number.isNaN(fiat) || fiat <= 0) return null;
+	const fiat = Number(trimmed);
+	if (!Number.isFinite(fiat) || fiat <= 0) return null;
+	if (!Number.isFinite(sellPrice) || sellPrice <= 0) return null;
 
 	return { usdc: fiat / sellPrice, fiat };
 }

--- a/src/qr-parsers/utils/crc16.ts
+++ b/src/qr-parsers/utils/crc16.ts
@@ -34,8 +34,12 @@ export function verifyCRC16(qrData: string): { valid: boolean; error?: string } 
 		return { valid: false, error: "QR data too short for CRC verification" };
 	}
 
-	const crcTagIndex = qrData.lastIndexOf("6304");
-	if (crcTagIndex === -1 || crcTagIndex + 8 !== qrData.length) {
+	// The CRC tag is always the final data object: "63" (tag) + "04" (length) +
+	// 4 hex CRC digits. It must sit at a fixed position (length - 8). Locating it
+	// positionally — rather than with lastIndexOf("6304") — avoids a false match
+	// when the CRC value itself is "6304" (payload ends "...63046304").
+	const crcTagIndex = qrData.length - 8;
+	if (qrData.substring(crcTagIndex, crcTagIndex + 4) !== "6304") {
 		return { valid: false, error: "Missing or misplaced CRC tag (6304)" };
 	}
 

--- a/test/qr-parsers/amount.test.ts
+++ b/test/qr-parsers/amount.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { parseAmount } from "../../src/qr-parsers/utils/amount";
+
+describe("parseAmount", () => {
+	it("parses a plain decimal amount and converts to usdc", () => {
+		expect(parseAmount("100", 2)).toEqual({ fiat: 100, usdc: 50 });
+		expect(parseAmount("10.50", 5)).toEqual({ fiat: 10.5, usdc: 2.1 });
+	});
+
+	it("trims surrounding whitespace", () => {
+		expect(parseAmount("  25  ", 5)).toEqual({ fiat: 25, usdc: 5 });
+	});
+
+	it("returns null for empty or blank input", () => {
+		expect(parseAmount("", 5)).toBeNull();
+		expect(parseAmount("   ", 5)).toBeNull();
+	});
+
+	it("returns null for non-positive amounts", () => {
+		expect(parseAmount("0", 5)).toBeNull();
+		expect(parseAmount("-10", 5)).toBeNull();
+	});
+
+	// Regression: parseFloat used to accept a valid numeric prefix and ignore the
+	// rest, letting malformed QR amount fields through as a bogus "success".
+	it("rejects trailing garbage", () => {
+		expect(parseAmount("12abc", 5)).toBeNull();
+		expect(parseAmount("10 20", 5)).toBeNull();
+	});
+
+	// Regression: parseFloat accepted "Infinity" and exponent notation, producing
+	// non-finite or unexpected amounts from a QR field.
+	it("rejects Infinity, NaN, and exponent notation", () => {
+		expect(parseAmount("Infinity", 5)).toBeNull();
+		expect(parseAmount("NaN", 5)).toBeNull();
+		expect(parseAmount("1e3", 5)).toBeNull();
+	});
+
+	// Regression: an unvalidated sellPrice of 0 produced Infinity usdc, and a
+	// negative sellPrice produced a negative usdc amount.
+	it("rejects a zero, negative, or non-finite sellPrice", () => {
+		expect(parseAmount("100", 0)).toBeNull();
+		expect(parseAmount("100", -2)).toBeNull();
+		expect(parseAmount("100", Number.NaN)).toBeNull();
+		expect(parseAmount("100", Number.POSITIVE_INFINITY)).toBeNull();
+	});
+});

--- a/test/qr-parsers/crc16.test.ts
+++ b/test/qr-parsers/crc16.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { calculateCRC16, verifyCRC16 } from "../../src/qr-parsers/utils/crc16";
+
+describe("calculateCRC16", () => {
+	// EMVCo spec reference payload (SGQR test vector).
+	it("matches the EMVCo reference vector", () => {
+		const payload =
+			"00020101021229300012D156000000000510A93FO3230Q31280012D15600000001030812345678520441115802CN5914BEST TRANSPORT6007BEIJING64200002ZH0104最佳运输0202北京540523.7253031565502016233030412340603***0708A60086670902ME91320016A0112233449988770708123456786304";
+		expect(calculateCRC16(payload.replace(/6304$/, ""))).toBe("A13A");
+	});
+
+	it("zero-pads the checksum to 4 hex digits", () => {
+		const crc = calculateCRC16("000201");
+		expect(crc).toMatch(/^[0-9A-F]{4}$/);
+	});
+});
+
+describe("verifyCRC16", () => {
+	it("accepts a QR whose checksum matches", () => {
+		const inner = "0002015802CN";
+		const qr = `${inner}6304${calculateCRC16(inner)}`;
+		expect(verifyCRC16(qr)).toEqual({ valid: true });
+	});
+
+	// Regression: when the computed CRC is literally "6304", the payload ends
+	// "...63046304". Locating the tag with lastIndexOf("6304") matched the value
+	// and falsely reported a misplaced tag. It must be located positionally.
+	it("accepts a valid QR whose checksum is exactly 6304", () => {
+		const inner = "000201041162";
+		expect(calculateCRC16(inner)).toBe("6304");
+		const qr = `${inner}6304${calculateCRC16(inner)}`; // "...63046304"
+		expect(verifyCRC16(qr)).toEqual({ valid: true });
+	});
+
+	it("rejects a QR with a corrupted checksum", () => {
+		const inner = "0002015802CN";
+		const qr = `${inner}6304${calculateCRC16(inner)}`;
+		const tampered = `${qr.slice(0, -1)}${qr.at(-1) === "0" ? "1" : "0"}`;
+		const result = verifyCRC16(tampered);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("CRC mismatch");
+	});
+
+	it("rejects a string too short to hold a CRC tag", () => {
+		expect(verifyCRC16("6304").valid).toBe(false);
+	});
+
+	it("rejects when the final data object is not the CRC tag", () => {
+		// Ends with a well-formed 8-char suffix, but the tag is "5904" not "6304".
+		const result = verifyCRC16("00020159041234");
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("Missing or misplaced CRC tag");
+	});
+
+	it("rejects a non-hex CRC value", () => {
+		const result = verifyCRC16("0002016304ZZZZ");
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("Invalid CRC hex format");
+	});
+});

--- a/test/qr-parsers/idr.test.ts
+++ b/test/qr-parsers/idr.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from "vitest";
 import { parseQRIS } from "../../src/qr-parsers/parsers/idr";
+import { calculateCRC16 } from "../../src/qr-parsers/utils/crc16";
 
 const SELL_PRICE = 16000;
 
 function tlv(tag: string, value: string): string {
 	return `${tag}${value.length.toString().padStart(2, "0")}${value}`;
+}
+
+/** Append the EMVCo CRC tag (63) so the payload passes checksum verification. */
+function withCRC(data: string): string {
+	return `${data}6304${calculateCRC16(data)}`;
 }
 
 function unwrap<T, E>(r: { isOk(): boolean; isErr(): boolean; value?: T; error?: E }) {
@@ -14,21 +20,21 @@ function unwrap<T, E>(r: { isOk(): boolean; isErr(): boolean; value?: T; error?:
 
 describe("parseQRIS (IDR)", () => {
 	it("parses merchant name only", () => {
-		const qr = `000201${tlv("59", "ACME STORE")}`;
+		const qr = withCRC(`000201${tlv("59", "ACME STORE")}`);
 		const data = unwrap(parseQRIS(qr, SELL_PRICE));
 		expect(data.paymentAddress).toBe("ACME STORE");
 		expect(data.amount).toBeUndefined();
 	});
 
 	it("parses merchant with amount and converts to usdc", () => {
-		const qr = `000201${tlv("59", "ACME")}${tlv("54", "16000")}`;
+		const qr = withCRC(`000201${tlv("59", "ACME")}${tlv("54", "16000")}`);
 		const data = unwrap(parseQRIS(qr, SELL_PRICE));
 		expect(data.paymentAddress).toBe("ACME");
 		expect(data.amount).toEqual({ fiat: 16000, usdc: 1 });
 	});
 
 	it("trims whitespace", () => {
-		const qr = `  ${tlv("59", "ACME")}  `;
+		const qr = `  ${withCRC(`000201${tlv("59", "ACME")}`)}  `;
 		expect(unwrap(parseQRIS(qr, SELL_PRICE)).paymentAddress).toBe("ACME");
 	});
 
@@ -42,28 +48,45 @@ describe("parseQRIS (IDR)", () => {
 	});
 
 	it("returns INVALID_QR when merchant name tag 59 is missing", () => {
-		const qr = `000201${tlv("54", "100")}`;
+		const qr = withCRC(`000201${tlv("54", "100")}`);
 		const result = parseQRIS(qr, SELL_PRICE);
 		expect(result.isErr()).toBe(true);
 		if (result.isErr()) expect(result.error.code).toBe("INVALID_QR");
 	});
 
 	it("returns INVALID_AMOUNT for non-parseable amount tag", () => {
-		const qr = `000201${tlv("59", "ACME")}${tlv("54", "xyz")}`;
+		const qr = withCRC(`000201${tlv("59", "ACME")}${tlv("54", "xyz")}`);
 		const result = parseQRIS(qr, SELL_PRICE);
 		expect(result.isErr()).toBe(true);
 		if (result.isErr()) expect(result.error.code).toBe("INVALID_AMOUNT");
 	});
+
+	it("returns INVALID_QR when the CRC tag is missing", () => {
+		const qr = `000201${tlv("59", "ACME")}`;
+		const result = parseQRIS(qr, SELL_PRICE);
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) expect(result.error.code).toBe("INVALID_QR");
+	});
+
+	it("returns INVALID_QR when the CRC has been tampered with", () => {
+		const qr = `${withCRC(`000201${tlv("59", "ACME")}`).slice(0, -4)}0000`;
+		const result = parseQRIS(qr, SELL_PRICE);
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) expect(result.error.code).toBe("INVALID_QR");
+	});
 });
 
 describe("parseQRIS (IDR) — real-world examples", () => {
-	// EMVCo MPM QRIS, dynamic, currency 360 (IDR), country ID, amount 50000, MCC 4829
-	const QRIS_WITH_AMOUNT =
-		"00020101021226570016ID.CO.SAMPLE.WWW01189360091400001234560211000000000015204482953033605405500005802ID5918WARUNG CONTOH SATU601212345 KOTA A";
+	// EMVCo MPM QRIS, dynamic, currency 360 (IDR), country ID, amount 50000, MCC 4829.
+	// CRC (tag 63) recomputed over the payload so the checksum is valid.
+	const QRIS_WITH_AMOUNT = withCRC(
+		"00020101021226570016ID.CO.SAMPLE.WWW01189360091400001234560211000000000015204482953033605405500005802ID5918WARUNG CONTOH SATU601212345 KOTA A",
+	);
 
-	// EMVCo MPM QRIS, static, no amount, MCC 5411
-	const QRIS_NO_AMOUNT =
-		"00020101021126430017ID.CO.EXAMPLE.WWW01189360098800009876545204541153033605802ID5915TOKO CONTOH DUA600905 KOTA B";
+	// EMVCo MPM QRIS, static, no amount, MCC 5411. CRC recomputed for validity.
+	const QRIS_NO_AMOUNT = withCRC(
+		"00020101021126430017ID.CO.EXAMPLE.WWW01189360098800009876545204541153033605802ID5915TOKO CONTOH DUA600905 KOTA B",
+	);
 
 	it("parses a dynamic QRIS with amount", () => {
 		const data = unwrap(parseQRIS(QRIS_WITH_AMOUNT, SELL_PRICE));
@@ -75,5 +98,13 @@ describe("parseQRIS (IDR) — real-world examples", () => {
 		const data = unwrap(parseQRIS(QRIS_NO_AMOUNT, SELL_PRICE));
 		expect(data.paymentAddress).toBe("TOKO CONTOH DUA");
 		expect(data.amount).toBeUndefined();
+	});
+
+	it("rejects a real-world QRIS whose amount has been tampered with", () => {
+		// Flip the amount tag 54 value 50000 → 60000 without recomputing the CRC.
+		const tampered = QRIS_WITH_AMOUNT.replace("5405500005", "5405600005");
+		const result = parseQRIS(tampered, SELL_PRICE);
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) expect(result.error.code).toBe("INVALID_QR");
 	});
 });

--- a/test/qr-parsers/parse-qr.test.ts
+++ b/test/qr-parsers/parse-qr.test.ts
@@ -26,7 +26,7 @@ describe("parseQR dispatcher", () => {
 	});
 
 	it("dispatches IDR to QRIS parser", async () => {
-		const qr = `000201${tlv("59", "STORE")}${tlv("54", "16000")}`;
+		const qr = withCrc(`000201${tlv("59", "STORE")}${tlv("54", "16000")}`);
 		const data = unwrap(await parseQR({ qrData: qr, currency: "IDR", sellPrice: 16000 }));
 		expect(data.paymentAddress).toBe("STORE");
 	});

--- a/test/qr-parsers/pen.test.ts
+++ b/test/qr-parsers/pen.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { parsePeru } from "../../src/qr-parsers/parsers/pen";
+import { calculateCRC16 } from "../../src/qr-parsers/utils/crc16";
 
 const SELL_PRICE = 3.75;
 
@@ -9,6 +10,11 @@ const SAMPLE =
 
 function tlv(tag: string, value: string): string {
 	return `${tag}${value.length.toString().padStart(2, "0")}${value}`;
+}
+
+/** Append the EMVCo CRC tag (63) so the payload passes checksum verification. */
+function withCRC(data: string): string {
+	return `${data}6304${calculateCRC16(data)}`;
 }
 
 function unwrap<T, E>(r: { isOk(): boolean; isErr(): boolean; value?: T; error?: E }) {
@@ -24,7 +30,9 @@ describe("parsePeru (PEN)", () => {
 	});
 
 	it("parses an amount (tag 54) and converts to usdc", () => {
-		const withAmount = `000201${tlv("53", "604")}${tlv("54", "1500")}${tlv("58", "PE")}${tlv("59", "YAPERO")}`;
+		const withAmount = withCRC(
+			`000201${tlv("53", "604")}${tlv("54", "1500")}${tlv("58", "PE")}${tlv("59", "YAPERO")}`,
+		);
 		const data = unwrap(parsePeru(withAmount, SELL_PRICE));
 		expect(data.paymentAddress).toBe(withAmount);
 		expect(data.amount).toEqual({ fiat: 1500, usdc: 1500 / SELL_PRICE });
@@ -42,6 +50,21 @@ describe("parsePeru (PEN)", () => {
 	it("returns INVALID_QR for a non-Peru currency (tag 53 not 604)", () => {
 		const tweaked = SAMPLE.replace("5303604", "5303840");
 		const result = parsePeru(tweaked, SELL_PRICE);
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) expect(result.error.code).toBe("INVALID_QR");
+	});
+
+	it("returns INVALID_QR when the CRC has been tampered with", () => {
+		// Corrupt the merchant name (tag 59) without recomputing the CRC.
+		const tampered = SAMPLE.replace("5906YAPERO", "5906YAPERX");
+		const result = parsePeru(tampered, SELL_PRICE);
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) expect(result.error.code).toBe("INVALID_QR");
+	});
+
+	it("returns INVALID_QR when the CRC tag is missing", () => {
+		const noCrc = `000201${tlv("53", "604")}${tlv("58", "PE")}${tlv("59", "YAPERO")}`;
+		const result = parsePeru(noCrc, SELL_PRICE);
 		expect(result.isErr()).toBe(true);
 		if (result.isErr()) expect(result.error.code).toBe("INVALID_QR");
 	});


### PR DESCRIPTION
Fixes a real integrity/security gap in the QR parsers. QRIS (Indonesia) and Yape/Plin (Peru) are EMVCo QR codes that carry a mandatory CRC-16 checksum (tag 63) covering the entire payload. The parsers extracted and trusted those fields but never verified the checksum, even though sibling parsers (QR Ph, PIX, MercadoPago, NGN) already do. That means a corrupted scan or a tampered payload could be silently accepted and passed downstream into a payment flow.

**What the PR does**
* Routes both parsers through the existing `verifyCRC16` util and rejects with `INVALID_QR` on a missing or mismatched checksum, bringing them in line with the rest of the module. 
* `parseQRIS` also picks up the JSDoc that CLAUDE.md's commenting rules require.
* Follows the codebase's own conventions exactly (reuses `verifyCRC16`, matches the `crc.error ?? "…"` pattern, keeps the `ResultAsync/failure()` style, adds a changeset).
* Adds real regression tests: valid checksum passes, missing CRC tag rejected, and tampered-payload rejection for both currencies.

**Note to maintainers:** making CRC mandatory is the correct EMVCo behavior and matches the sibling parsers, but if you have ever seen real-world QRIS/Yape codes in the wild that omit the checksum, they may prefer a "verify-if-present" variant — happy to adjust if raised in review.
