### PR TITLE
ci: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Build
+        run: bun run build
+
       - name: Typecheck
         run: bun run typecheck
 
@@ -38,6 +41,3 @@ jobs:
         run: bun run test
         env:
           PIX_PROXY_URL: https://mock-pix-proxy.test
-
-      - name: Build
-        run: bun run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate SDK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun run test
+        env:
+          PIX_PROXY_URL: https://mock-pix-proxy.test
+
+      - name: Build
+        run: bun run build


### PR DESCRIPTION
## Summary

Adds GitHub Actions CI for the SDK to automatically validate pull requests and pushes to `dev` and `main`.

The workflow runs:

- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun run test`
- `bun run build`

### Details

- Uses the Bun version pinned in `package.json`
- Runs on pull requests targeting `dev` and `main`
- Runs on pushes to `dev` and `main`
- Cancels outdated runs for the same ref
- Provides the required `PIX_PROXY_URL` test environment variable
- Uses a single lightweight validation job

### Validation

All checks pass locally:

- Typecheck: passed
- Tests: 33 test files, 495 tests passed
- Build: passed

Lint was intentionally not included because the repository's current project-wide `bun run lint` reports pre-existing formatting issues across the existing `src/` tree. Keeping it out of this PR allows CI to be introduced as a green baseline without mixing in an unrelated repository-wide formatting change.

No existing source files or configuration were modified.