### PR TITLE
fix(fraud-engine): validate API responses with Zod

### DIFF
--- a/src/fraud-engine/client.ts
+++ b/src/fraud-engine/client.ts
@@ -18,7 +18,13 @@ import type {
 	ProcessBuyOrderResult,
 	UserDetails,
 } from "./types";
-import { validate, ZodFraudEngineConfigSchema } from "./validation";
+import {
+	validate,
+	ZodFingerprintLogResultSchema,
+	ZodFraudCheckApiResponseSchema,
+	ZodFraudEngineConfigSchema,
+	ZodLinkOrderResultSchema,
+} from "./validation";
 
 export function createFraudEngine(config: FraudEngineConfig): FraudEngine {
 	const { apiUrl, encryptionKey } = config;
@@ -76,7 +82,12 @@ export function createFraudEngine(config: FraudEngineConfig): FraudEngine {
 					});
 				}
 
-				const data = (await response.json()) as LinkOrderResult;
+				const json = await response.json();
+				const result = validate(ZodLinkOrderResultSchema, json);
+				if (result.isErr()) {
+					throw result.error;
+				}
+				const data = result.value;
 				logger.info("Order linked successfully", { orderId });
 				return data;
 			})(),
@@ -161,7 +172,12 @@ export function createFraudEngine(config: FraudEngineConfig): FraudEngine {
 			});
 		}
 
-		const data = (await response.json()) as FraudCheckApiResponse;
+		const json = await response.json();
+		const result = validate(ZodFraudCheckApiResponseSchema, json);
+		if (result.isErr()) {
+			throw result.error;
+		}
+		const data = result.value;
 		logger.info("Fraud check result", {
 			approved: data.approved,
 			activityLogId: data.activity_log_id,
@@ -318,7 +334,12 @@ export function createFraudEngine(config: FraudEngineConfig): FraudEngine {
 						});
 					}
 
-					const data = (await response.json()) as FingerprintLogResult;
+					const json = await response.json();
+					const result = validate(ZodFingerprintLogResultSchema, json);
+					if (result.isErr()) {
+						throw result.error;
+					}
+					const data = result.value;
 					logger.info("Fingerprint logged successfully");
 					return data;
 				})(),

--- a/src/fraud-engine/validation.ts
+++ b/src/fraud-engine/validation.ts
@@ -41,6 +41,25 @@ export const ZodLinkOrderParamsSchema = z.object({
 	orderId: z.string().min(1),
 });
 
+// ── Response schemas ───────────────────────────────────────────────────
+
+export const ZodFraudCheckApiResponseSchema = z.object({
+	success: z.boolean(),
+	approved: z.boolean(),
+	activity_log_id: z.number(),
+	message: z.string(),
+});
+
+export const ZodLinkOrderResultSchema = z.object({
+	success: z.boolean(),
+	message: z.string(),
+});
+
+export const ZodFingerprintLogResultSchema = z.object({
+	success: z.boolean(),
+	message: z.string(),
+});
+
 // ── Validate helper ────────────────────────────────────────────────────
 
 export function validate<S extends z.ZodType>(

--- a/test/fraud-engine/client.test.ts
+++ b/test/fraud-engine/client.test.ts
@@ -1,0 +1,374 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@seontechnologies/seon-javascript-sdk", () => ({
+	default: {
+		init: vi.fn(),
+		getSession: vi.fn().mockResolvedValue("mock-seon-session"),
+	},
+}));
+
+vi.mock("@fingerprintjs/fingerprintjs", () => ({
+	default: {
+		load: vi.fn().mockResolvedValue({
+			get: vi.fn().mockResolvedValue({
+				visitorId: "mock-visitor-id",
+				confidence: { score: 0.95 },
+			}),
+		}),
+	},
+}));
+
+import { createFraudEngine } from "../../src/fraud-engine/client";
+import * as deviceModule from "../../src/fraud-engine/device";
+import type { BuyOrderDetails, FraudEngineSigner } from "../../src/fraud-engine/types";
+
+const API_URL = "https://api.fraud.example.com";
+// 32-byte hex key (64 hex characters)
+const ENCRYPTION_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+const MOCK_SIGNER: FraudEngineSigner = {
+	address: "0x1234567890123456789012345678901234567890",
+	signMessage: vi.fn().mockResolvedValue("0xmockedsignature"),
+};
+
+const MOCK_ORDER_DETAILS: BuyOrderDetails = {
+	cryptoAmount: 100,
+	fiatAmount: 100,
+	currency: "INR",
+	recipientAddress: "0x1234567890123456789012345678901234567890",
+	fee: 1,
+	amountAfterFee: 99,
+};
+
+function jsonResponse(data: unknown, status = 200) {
+	return new Response(JSON.stringify(data), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+function mockFetch(handler: (url: string, init?: RequestInit) => unknown) {
+	vi.stubGlobal(
+		"fetch",
+		vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+			return Promise.resolve(handler(url, init));
+		}),
+	);
+}
+
+describe("fraud-engine client response validation", () => {
+	beforeEach(() => {
+		vi.spyOn(deviceModule, "getDeviceDetails").mockResolvedValue({
+			userAgent: "test-agent",
+			platform: "test-platform",
+			language: "en",
+			languages: ["en"],
+			screenWidth: 1920,
+			screenHeight: 1080,
+			devicePixelRatio: 1,
+			timezone: "UTC",
+			timezoneOffset: 0,
+			cookiesEnabled: true,
+			doNotTrack: null,
+			online: true,
+			touchSupport: false,
+			maxTouchPoints: 0,
+			vendor: "test-vendor",
+			appVersion: "1.0",
+			colorDepth: 24,
+			pixelDepth: 24,
+			ip: "127.0.0.1",
+			seonSession: "mock-seon-session",
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+	});
+
+	// ── checkBuyOrder ──────────────────────────────────────────────────────────
+
+	describe("checkBuyOrder", () => {
+		it("accepts a valid fraud check response", async () => {
+			mockFetch((url) => {
+				if (url.includes("/activity-logs")) {
+					return jsonResponse({
+						success: true,
+						approved: true,
+						activity_log_id: 12345,
+						message: "approved",
+					});
+				}
+				return jsonResponse({});
+			});
+
+			const engine = createFraudEngine({ apiUrl: API_URL, encryptionKey: ENCRYPTION_KEY });
+			const result = await engine.checkBuyOrder({
+				signer: MOCK_SIGNER,
+				orderDetails: MOCK_ORDER_DETAILS,
+			});
+
+			expect(result.isOk()).toBe(true);
+			const data = result._unsafeUnwrap();
+			expect(data.approved).toBe(true);
+			expect(data.activityLogId).toBe(12345);
+			expect(data.message).toBe("approved");
+			expect(typeof data.linkOrder).toBe("function");
+		});
+
+		it("rejects a response missing approved", async () => {
+			mockFetch((url) => {
+				if (url.includes("/activity-logs")) {
+					return jsonResponse({
+						success: true,
+						activity_log_id: 12345,
+						message: "missing approved",
+					});
+				}
+				return jsonResponse({});
+			});
+
+			const engine = createFraudEngine({ apiUrl: API_URL, encryptionKey: ENCRYPTION_KEY });
+			const result = await engine.checkBuyOrder({
+				signer: MOCK_SIGNER,
+				orderDetails: MOCK_ORDER_DETAILS,
+			});
+
+			expect(result.isErr()).toBe(true);
+			const error = result._unsafeUnwrapErr();
+			expect(error.code).toBe("VALIDATION_ERROR");
+		});
+
+		it("rejects a response missing activity_log_id", async () => {
+			mockFetch((url) => {
+				if (url.includes("/activity-logs")) {
+					return jsonResponse({
+						success: true,
+						approved: true,
+						message: "missing activity_log_id",
+					});
+				}
+				return jsonResponse({});
+			});
+
+			const engine = createFraudEngine({ apiUrl: API_URL, encryptionKey: ENCRYPTION_KEY });
+			const result = await engine.checkBuyOrder({
+				signer: MOCK_SIGNER,
+				orderDetails: MOCK_ORDER_DETAILS,
+			});
+
+			expect(result.isErr()).toBe(true);
+			const error = result._unsafeUnwrapErr();
+			expect(error.code).toBe("VALIDATION_ERROR");
+		});
+
+		it("rejects a response with the wrong type for approved", async () => {
+			mockFetch((url) => {
+				if (url.includes("/activity-logs")) {
+					return jsonResponse({
+						success: true,
+						approved: "true", // string instead of boolean
+						activity_log_id: 12345,
+						message: "wrong type for approved",
+					});
+				}
+				return jsonResponse({});
+			});
+
+			const engine = createFraudEngine({ apiUrl: API_URL, encryptionKey: ENCRYPTION_KEY });
+			const result = await engine.checkBuyOrder({
+				signer: MOCK_SIGNER,
+				orderDetails: MOCK_ORDER_DETAILS,
+			});
+
+			expect(result.isErr()).toBe(true);
+			const error = result._unsafeUnwrapErr();
+			expect(error.code).toBe("VALIDATION_ERROR");
+		});
+
+		it("rejects an empty object response", async () => {
+			mockFetch(() => jsonResponse({}));
+
+			const engine = createFraudEngine({ apiUrl: API_URL, encryptionKey: ENCRYPTION_KEY });
+			const result = await engine.checkBuyOrder({
+				signer: MOCK_SIGNER,
+				orderDetails: MOCK_ORDER_DETAILS,
+			});
+
+			expect(result.isErr()).toBe(true);
+			const error = result._unsafeUnwrapErr();
+			expect(error.code).toBe("VALIDATION_ERROR");
+		});
+	});
+
+	// ── linkOrder ──────────────────────────────────────────────────────────────
+
+	describe("linkOrder", () => {
+		it("accepts a valid link order response", async () => {
+			mockFetch((url: string) => {
+				if (url.includes("/link-order")) {
+					return jsonResponse({
+						success: true,
+						message: "order linked successfully",
+					});
+				}
+				return jsonResponse({
+					success: true,
+					approved: true,
+					activity_log_id: 12345,
+					message: "approved",
+				});
+			});
+
+			const engine = createFraudEngine({ apiUrl: API_URL, encryptionKey: ENCRYPTION_KEY });
+			const checkResult = await engine.checkBuyOrder({
+				signer: MOCK_SIGNER,
+				orderDetails: MOCK_ORDER_DETAILS,
+			});
+			expect(checkResult.isOk()).toBe(true);
+
+			const linkResult = await checkResult._unsafeUnwrap().linkOrder("order_123");
+			expect(linkResult.isOk()).toBe(true);
+			expect(linkResult._unsafeUnwrap()).toEqual({
+				success: true,
+				message: "order linked successfully",
+			});
+		});
+
+		it("rejects a response missing a required field (missing message)", async () => {
+			mockFetch((url: string) => {
+				if (url.includes("/link-order")) {
+					return jsonResponse({
+						success: true,
+					});
+				}
+				return jsonResponse({
+					success: true,
+					approved: true,
+					activity_log_id: 12345,
+					message: "approved",
+				});
+			});
+
+			const engine = createFraudEngine({ apiUrl: API_URL, encryptionKey: ENCRYPTION_KEY });
+			const checkResult = await engine.checkBuyOrder({
+				signer: MOCK_SIGNER,
+				orderDetails: MOCK_ORDER_DETAILS,
+			});
+			expect(checkResult.isOk()).toBe(true);
+
+			const linkResult = await checkResult._unsafeUnwrap().linkOrder("order_123");
+			expect(linkResult.isErr()).toBe(true);
+			const error = linkResult._unsafeUnwrapErr();
+			expect(error.code).toBe("VALIDATION_ERROR");
+		});
+
+		it("rejects a response with an incorrect field type (success as string)", async () => {
+			mockFetch((url: string) => {
+				if (url.includes("/link-order")) {
+					return jsonResponse({
+						success: "true",
+						message: "order linked",
+					});
+				}
+				return jsonResponse({
+					success: true,
+					approved: true,
+					activity_log_id: 12345,
+					message: "approved",
+				});
+			});
+
+			const engine = createFraudEngine({ apiUrl: API_URL, encryptionKey: ENCRYPTION_KEY });
+			const checkResult = await engine.checkBuyOrder({
+				signer: MOCK_SIGNER,
+				orderDetails: MOCK_ORDER_DETAILS,
+			});
+			expect(checkResult.isOk()).toBe(true);
+
+			const linkResult = await checkResult._unsafeUnwrap().linkOrder("order_123");
+			expect(linkResult.isErr()).toBe(true);
+			const error = linkResult._unsafeUnwrapErr();
+			expect(error.code).toBe("VALIDATION_ERROR");
+		});
+	});
+
+	// ── logFingerprint ─────────────────────────────────────────────────────────
+
+	describe("logFingerprint", () => {
+		it("accepts a valid fingerprint log response", async () => {
+			mockFetch(() =>
+				jsonResponse({
+					success: true,
+					message: "fingerprint logged",
+				}),
+			);
+
+			const engine = createFraudEngine({ apiUrl: API_URL, encryptionKey: ENCRYPTION_KEY });
+			const result = await engine.logFingerprint({ signer: MOCK_SIGNER });
+
+			expect(result.isOk()).toBe(true);
+			expect(result._unsafeUnwrap()).toEqual({
+				success: true,
+				message: "fingerprint logged",
+			});
+		});
+
+		it("rejects a malformed fingerprint log response (wrong types)", async () => {
+			mockFetch(() =>
+				jsonResponse({
+					success: "true", // string instead of boolean
+					message: 123, // number instead of string
+				}),
+			);
+
+			const engine = createFraudEngine({ apiUrl: API_URL, encryptionKey: ENCRYPTION_KEY });
+			const result = await engine.logFingerprint({ signer: MOCK_SIGNER });
+
+			expect(result.isErr()).toBe(true);
+			const error = result._unsafeUnwrapErr();
+			expect(error.code).toBe("VALIDATION_ERROR");
+		});
+
+		it("rejects an empty object response", async () => {
+			mockFetch(() => jsonResponse({}));
+
+			const engine = createFraudEngine({ apiUrl: API_URL, encryptionKey: ENCRYPTION_KEY });
+			const result = await engine.logFingerprint({ signer: MOCK_SIGNER });
+
+			expect(result.isErr()).toBe(true);
+			const error = result._unsafeUnwrapErr();
+			expect(error.code).toBe("VALIDATION_ERROR");
+		});
+	});
+
+	// ── processBuyOrder fail-open regression ───────────────────────────────────
+
+	describe("processBuyOrder", () => {
+		it("preserves fail-open behavior and does not throw unhandled runtime exceptions on malformed response", async () => {
+			mockFetch(() =>
+				jsonResponse({
+					success: true,
+					approved: "true", // invalid type: validation error triggers catch in processBuyOrder
+				}),
+			);
+
+			const placeOrderMock = vi.fn().mockResolvedValue("onchain_order_456");
+
+			const engine = createFraudEngine({ apiUrl: API_URL, encryptionKey: ENCRYPTION_KEY });
+			const result = await engine.processBuyOrder({
+				signer: MOCK_SIGNER,
+				orderDetails: MOCK_ORDER_DETAILS,
+				placeOrder: placeOrderMock,
+			});
+
+			expect(result.isOk()).toBe(true);
+			expect(placeOrderMock).toHaveBeenCalledTimes(1);
+			expect(result._unsafeUnwrap()).toEqual({
+				status: "placed",
+				orderId: "onchain_order_456",
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Summary

The fraud-engine client was trusting HTTP API responses through TypeScript type assertions instead of performing runtime validation.

This PR adds Zod response validation at all fraud-engine API boundaries, following the SDK's existing validation pattern.

## Changes

* Added `ZodFraudCheckApiResponseSchema`
* Added `ZodLinkOrderResultSchema`
* Added `ZodFingerprintLogResultSchema`
* Replaced response type assertions with the existing `validate()` helper
* Added regression tests covering valid and malformed API responses
* Verified that validation failures surface as `VALIDATION_ERROR`
* Preserved the existing fail-open behavior in `processBuyOrder`

## Why

TypeScript type assertions do not validate data at runtime. If the fraud-engine API returns an unexpected or malformed payload, the SDK could previously treat it as a valid response.

Runtime Zod validation ensures malformed responses are rejected at the API boundary before they are consumed by the SDK.

## Testing

* `bun run test test/fraud-engine/client.test.ts` ✅
* `bun run build` ✅
* `bun run typecheck` ✅
* `bunx @biomejs/biome check src/fraud-engine/` ✅
* `git diff --check` ✅

The full test suite has one pre-existing failure related to the `PIX_PROXY_URL` test environment configuration, unrelated to this change.

No dependencies were added or modified.
