### PR TITLE
feat(country): getPayQrPayload for Scan & Pay plus CUP transfer warning

### DIFF
--- a/.changeset/catalog-qr-typed-coexist.md
+++ b/.changeset/catalog-qr-typed-coexist.md
@@ -1,0 +1,9 @@
+---
+"@p2pdotme/sdk": minor
+---
+
+country: QR and typed payment fields may coexist
+
+- `packStoredPaymentId` keeps a typed rest whenever any field has text, so a partial draft cannot hide behind a valid QR.
+- `validateStoredPaymentId` / `validateCatalogPaymentDraft(currency, qr, fieldValues)`: QR-only, typed-only, or both; if any typed field is filled, catalog `optional` rules apply. Apps validate the form with this; field errors come from `PAYMENT_ID_FIELDS[].validationErrorMessage`.
+- `validateVenezuelanPaymentId` / `validatePeruvianPaymentId` reject a packed ID whose rest is present but invalid.

--- a/.changeset/cup-transfer-warning.md
+++ b/.changeset/cup-transfer-warning.md
@@ -1,0 +1,9 @@
+---
+"@p2pdotme/sdk": minor
+---
+
+country: optional transfer warning key on CountryOption
+
+- `transferWarning?` on `CountryOption` holds an i18n key shown before the payer sends fiat.
+- `getTransferWarning(currency)` reads it (same pattern as `uploadsPaymentQR`). Apps must not branch on currency.
+- CUP sets `CUP_BANDEC_WARNING` (BANDEC delays / disputes). Translations live in the apps.

--- a/.changeset/pay-qr-payload.md
+++ b/.changeset/pay-qr-payload.md
@@ -4,6 +4,6 @@
 
 country: `getPayQrPayload` for PAY QR display; Scan & Pay uses SELL `validateQr`
 
-- Optional `CountryOption.getPayQrPayload` plus dispatcher `getPayQrPayload(currency, id)` (strict `getStoredQrPayload` first, then the hook). Apps re-draw scanned QRs without branching on PEN/VEN/PHP.
-- PAY display may be looser than upload (Yape/Plin without CRC, Pago Móvil without `merchantId`, PHP QR Ph vs InstaPay `phone|bank`). `assignStoredPaymentIdToFieldValues` no longer dumps a standalone PAY blob into typed fields.
-- Scan & Pay parsers align with SELL: `parsePeru` requires CRC (`validatePeruvianQr`); `parsePagoMovil` / `isPagoMovilQr` require the S7B envelope (`validateVenezuelanQr`). `parseQR` re-checks `validateQr` when the country has one.
+- Optional `CountryOption.getPayQrPayload` plus dispatcher `getPayQrPayload(currency, id)` (strict `getStoredQrPayload` first, then the hook). Apps re-draw scanned QRs without branching on PEN/VEN/BOB/PHP.
+- PAY display may be looser than upload (Yape/Plin without CRC, Pago Móvil without `merchantId`, BOB EMVCo without CRC or a non-24/32 hex envelope, PHP QR Ph vs InstaPay `phone|bank`). `assignStoredPaymentIdToFieldValues` no longer dumps a standalone PAY blob into typed fields.
+- Scan & Pay parsers align with SELL: `parsePeru` requires CRC (`validatePeruvianQr`); `parsePagoMovil` / `isPagoMovilQr` require the S7B envelope (`validateVenezuelanQr`); BOB uses `validateBolivianQr`. `parseQR` re-checks `validateQr` when the country has one.

--- a/.changeset/pay-qr-payload.md
+++ b/.changeset/pay-qr-payload.md
@@ -1,0 +1,9 @@
+---
+"@p2pdotme/sdk": minor
+---
+
+country: `getPayQrPayload` for PAY QR display; Scan & Pay uses SELL `validateQr`
+
+- Optional `CountryOption.getPayQrPayload` plus dispatcher `getPayQrPayload(currency, id)` (strict `getStoredQrPayload` first, then the hook). Apps re-draw scanned QRs without branching on PEN/VEN/PHP.
+- PAY display may be looser than upload (Yape/Plin without CRC, Pago Móvil without `merchantId`, PHP QR Ph vs InstaPay `phone|bank`). `assignStoredPaymentIdToFieldValues` no longer dumps a standalone PAY blob into typed fields.
+- Scan & Pay parsers align with SELL: `parsePeru` requires CRC (`validatePeruvianQr`); `parsePagoMovil` / `isPagoMovilQr` require the S7B envelope (`validateVenezuelanQr`). `parseQR` re-checks `validateQr` when the country has one.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p2pdotme/sdk",
-  "version": "1.2.19",
+  "version": "1.2.20",
   "description": "P2P.me SDK",
   "license": "MIT",
   "type": "module",

--- a/src/country/README.md
+++ b/src/country/README.md
@@ -83,15 +83,18 @@ validatePIXId("user@example.com"); // true
 `disabled: true` — hidden from selection in the UI.
 `uploadPaymentQR: true` — merchant/seller uploads a QR image as the payment address (PEN Yape/Plin, VEN Pago Móvil, BOB QR Simple). Omit or leave unset for everyone else. Distinct from `disabledPaymentTypes: ["PAY"]`, which gates the buyer scanning a QR to pay.
 
-Scan & pay (PAY) is a different path: `parseQR` stores the scanned blob as the payment ID. The merchant re-encodes that blob (`isPagoMovilQr` / `getStoredQrPayload` / per-currency PAY helpers). Do not reuse `uploadPaymentQR` to decide whether a PAY order shows a QR.
+Scan & pay (PAY) is a different path: `parseQR` stores the scanned blob as the payment ID. The merchant re-encodes that blob with `getPayQrPayload(currency, id)` (strict `getStoredQrPayload` first, then a per-country PAY hook). Do not reuse `uploadPaymentQR` to decide whether a PAY order shows a QR.
 
 `validateQr` — this currency may store a QR in the payment ID (`qr||fields` or standalone). `usesPackedPaymentId(currency)` is true when `validateQr` exists.
+
+`getPayQrPayload` — optional CountryOption hook for PAY **display**. Scan & Pay uses the same `validateQr` as SELL (`parsePeru` CRC, `parsePagoMovil` `merchantId`). The hook may still re-draw a blob already stored (PEN without CRC, VEN without `merchantId`, PHP QR Ph vs InstaPay `phone|bank`). Apps must not branch on currency.
 
 `optional: true` — empty value allowed for that field. If every field is optional, at least one must still be filled (`validatePaymentIdFields`). Packed QR + fields are validated with `validateStoredPaymentId`.
 
 ```typescript
 import {
   getStoredQrPayload,
+  getPayQrPayload,
   packStoredPaymentId,
   uploadsPaymentQR,
   usesCatalogPaymentForm,
@@ -107,6 +110,8 @@ usesCatalogPaymentForm("CUP"); // true — two typed fields, no QR upload
 validateStoredPaymentId("PEN", "987654321"); // true — phone-only
 packStoredPaymentId("PEN", qr, { phone: "987654321", cci: "" });
 getStoredQrPayload("PEN", storedId); // EMVCo blob or null
+getPayQrPayload("PEN", scannedBlob); // same, even if CRC fails
+getPayQrPayload("PHP", qrPhBlob); // QR Ph EMVCo; null for phone|bank
 ```
 
 ## Validators

--- a/src/country/README.md
+++ b/src/country/README.md
@@ -91,10 +91,13 @@ Scan & pay (PAY) is a different path: `parseQR` stores the scanned blob as the p
 
 `optional: true` — empty value allowed for that field. If every field is optional, at least one must still be filled (`validatePaymentIdFields`). Packed QR + fields are validated with `validateStoredPaymentId`.
 
+`transferWarning` — optional i18n key shown before the payer sends fiat (bank outage, delayed credits, etc.). Apps call `getTransferWarning(currency)` and translate with `t(key)`. Omit when there is no warning. Currently set on CUP (`CUP_BANDEC_WARNING`).
+
 ```typescript
 import {
   getStoredQrPayload,
   getPayQrPayload,
+  getTransferWarning,
   packStoredPaymentId,
   uploadsPaymentQR,
   usesCatalogPaymentForm,
@@ -107,6 +110,8 @@ uploadsPaymentQR("VEN"); // true — seller may upload a Pago Móvil QR
 uploadsPaymentQR("BOB"); // true — seller may upload a QR Simple QR
 usesPackedPaymentId("VEN"); // true — has validateQr
 usesCatalogPaymentForm("CUP"); // true — two typed fields, no QR upload
+getTransferWarning("CUP"); // "CUP_BANDEC_WARNING"
+getTransferWarning("INR"); // null
 validateStoredPaymentId("PEN", "987654321"); // true — phone-only
 packStoredPaymentId("PEN", qr, { phone: "987654321", cci: "" });
 getStoredQrPayload("PEN", storedId); // EMVCo blob or null

--- a/src/country/README.md
+++ b/src/country/README.md
@@ -22,7 +22,7 @@ Country and currency configuration for the P2P.me SDK — payment methods, valid
 │   ├── eur.ts           # Revolut EUR
 │   ├── usd.ts           # Revolut USD
 │   └── index.ts         # Re-exports all currency files
-├── qr-validator.ts      # SELL QR payload checks (PEN / VEN) — shared by both apps
+├── qr-validator.ts      # SELL QR payload checks (PEN / VEN / BOB) — shared by both apps
 ├── countries.ts         # COUNTRY_OPTIONS — aggregated from currencies/
 ├── payment-fields.ts    # PAYMENT_ID_FIELDS — aggregated from currencies/
 ├── validators.ts        # Re-exports all validators + compound utils
@@ -87,7 +87,7 @@ Scan & pay (PAY) is a different path: `parseQR` stores the scanned blob as the p
 
 `validateQr` — this currency may store a QR in the payment ID (`qr||fields` or standalone). `usesPackedPaymentId(currency)` is true when `validateQr` exists.
 
-`getPayQrPayload` — optional CountryOption hook for PAY **display**. Scan & Pay uses the same `validateQr` as SELL (`parsePeru` CRC, `parsePagoMovil` `merchantId`). The hook may still re-draw a blob already stored (PEN without CRC, VEN without `merchantId`, PHP QR Ph vs InstaPay `phone|bank`). Apps must not branch on currency.
+`getPayQrPayload` — optional CountryOption hook for PAY **display**. Scan & Pay uses the same `validateQr` as SELL (`parsePeru` CRC, `parsePagoMovil` `merchantId`, `validateBolivianQr` envelope/CRC). The hook may still re-draw a blob already stored (PEN without CRC, VEN without `merchantId`, BOB EMVCo without CRC or a non-24/32 hex envelope, PHP QR Ph vs InstaPay `phone|bank`). Apps must not branch on currency.
 
 `optional: true` — empty value allowed for that field. If every field is optional, at least one must still be filled (`validatePaymentIdFields`). Packed QR + fields are validated with `validateStoredPaymentId`.
 
@@ -116,6 +116,7 @@ validateStoredPaymentId("PEN", "987654321"); // true — phone-only
 packStoredPaymentId("PEN", qr, { phone: "987654321", cci: "" });
 getStoredQrPayload("PEN", storedId); // EMVCo blob or null
 getPayQrPayload("PEN", scannedBlob); // same, even if CRC fails
+getPayQrPayload("BOB", scannedBlob); // QR Simple EMVCo or encrypted envelope
 getPayQrPayload("PHP", qrPhBlob); // QR Ph EMVCo; null for phone|bank
 ```
 

--- a/src/country/README.md
+++ b/src/country/README.md
@@ -89,7 +89,7 @@ Scan & pay (PAY) is a different path: `parseQR` stores the scanned blob as the p
 
 `getPayQrPayload` — optional CountryOption hook for PAY **display**. Scan & Pay uses the same `validateQr` as SELL (`parsePeru` CRC, `parsePagoMovil` `merchantId`, `validateBolivianQr` envelope/CRC). The hook may still re-draw a blob already stored (PEN without CRC, VEN without `merchantId`, BOB EMVCo without CRC or a non-24/32 hex envelope, PHP QR Ph vs InstaPay `phone|bank`). Apps must not branch on currency.
 
-`optional: true` — empty value allowed for that field. If every field is optional, at least one must still be filled (`validatePaymentIdFields`). Packed QR + fields are validated with `validateStoredPaymentId`.
+`optional: true` — empty value allowed for that field. If every field is optional, at least one must still be filled (`validatePaymentIdFields`). Packed QR + fields are validated with `validateStoredPaymentId`. QR and typed fields may coexist; if any typed field has text, non-optional catalog fields are all required. Forms call `validateCatalogPaymentDraft(currency, qr, fieldValues)` and show `field.validationErrorMessage` on invalid fields. Layout copy (one generic “if they cannot scan, fill the details” hint) stays in the apps — not a per-country catalog hook.
 
 `transferWarning` — optional i18n key shown before the payer sends fiat (bank outage, delayed credits, etc.). Apps call `getTransferWarning(currency)` and translate with `t(key)`. Omit when there is no warning. Currently set on CUP (`CUP_BANDEC_WARNING`).
 
@@ -102,6 +102,7 @@ import {
   uploadsPaymentQR,
   usesCatalogPaymentForm,
   usesPackedPaymentId,
+  validateCatalogPaymentDraft,
   validateStoredPaymentId,
 } from "@p2pdotme/sdk/country";
 
@@ -148,7 +149,7 @@ getPayQrPayload("PHP", qrPhBlob); // QR Ph EMVCo; null for phone|bank
 
 ### Compound payment IDs
 
-Venezuela (VEN) requires three fields: phone, RIF, and bank name. Peru (PEN) has two **optional** fields (Yape/Plin phone and CCI); at least one must be present. Use the compound utilities to serialize/deserialize:
+Venezuela (VEN) requires three fields when the typed path is used: phone, RIF, and bank name. QR-only is also valid. Peru (PEN) has two **optional** fields (Yape/Plin phone and CCI); at least one must be present if there is typed text.
 
 ```typescript
 import {

--- a/src/country/countries.ts
+++ b/src/country/countries.ts
@@ -62,8 +62,8 @@ export function usesPackedPaymentId(currency: CurrencyCode | null | undefined): 
 }
 
 /**
- * Apps mount the catalog form (PackedPaymentInput): QR upload and/or
- * more than one typed field.
+ * Apps mount the catalog form (PackedPaymentInput): QR upload and typed
+ * fields may both show — they are not exclusive.
  */
 export function usesCatalogPaymentForm(currency: CurrencyCode | null | undefined): boolean {
 	if (!currency) return false;

--- a/src/country/countries.ts
+++ b/src/country/countries.ts
@@ -69,3 +69,11 @@ export function usesCatalogPaymentForm(currency: CurrencyCode | null | undefined
 	if (!currency) return false;
 	return uploadsPaymentQR(currency) || (PAYMENT_ID_FIELDS[currency]?.length ?? 0) > 1;
 }
+
+/**
+ * i18n key for a warning shown before the payer sends fiat, or `null` when the
+ * currency has none. Apps translate with `t(key)` — do not branch on currency.
+ */
+export function getTransferWarning(currency: CurrencyCode | null | undefined): string | null {
+	return getCountryOption(currency)?.transferWarning ?? null;
+}

--- a/src/country/currencies/bob.ts
+++ b/src/country/currencies/bob.ts
@@ -1,5 +1,5 @@
 import { CURRENCY } from "../currency";
-import { validateBolivianQr } from "../qr-validator";
+import { isBolivianPayQr, payQrCandidate, validateBolivianQr } from "../qr-validator";
 import type { CountryOption, PaymentIdFieldConfig } from "../types";
 
 export { validateBolivianQr };
@@ -52,4 +52,8 @@ export const BOB_COUNTRY_OPTION: CountryOption = {
 	disabledPaymentTypes: [],
 	uploadPaymentQR: true,
 	validateQr: validateBolivianQr,
+	getPayQrPayload: (paymentId) => {
+		const candidate = payQrCandidate(paymentId);
+		return isBolivianPayQr(candidate) ? candidate : null;
+	},
 };

--- a/src/country/currencies/cup.ts
+++ b/src/country/currencies/cup.ts
@@ -74,4 +74,5 @@ export const CUP_COUNTRY_OPTION: CountryOption = {
 	isAlpha: true,
 	disabled: false,
 	disabledPaymentTypes: [],
+	transferWarning: "CUP_BANDEC_WARNING",
 };

--- a/src/country/currencies/pen.ts
+++ b/src/country/currencies/pen.ts
@@ -1,5 +1,5 @@
 import { CURRENCY } from "../currency";
-import { validatePeruvianQr } from "../qr-validator";
+import { isPeruvianPayQr, payQrCandidate, validatePeruvianQr } from "../qr-validator";
 import { type CountryOption, PACKED_PAYMENT_ID_SEP, type PaymentIdFieldConfig } from "../types";
 
 export { validatePeruvianQr };
@@ -217,6 +217,10 @@ export const PEN_COUNTRY_OPTION: CountryOption = {
 	disabledPaymentTypes: [],
 	uploadPaymentQR: true,
 	validateQr: validatePeruvianQr,
+	getPayQrPayload: (paymentId) => {
+		const candidate = payQrCandidate(paymentId);
+		return isPeruvianPayQr(candidate) ? candidate : null;
+	},
 	hydrateFieldsFromQr: (qr) => {
 		const phone = extractPeruvianPhoneFromQr(qr);
 		return phone ? { phone } : {};

--- a/src/country/currencies/pen.ts
+++ b/src/country/currencies/pen.ts
@@ -166,11 +166,29 @@ export function serializePeruvianPaymentId(
 	return q || fallback;
 }
 
-/** QR payload and/or CCI and/or Yape/Plin phone. */
+function isValidPeruvianTypedRest(value: string): boolean {
+	const nonempty = value
+		.split("|")
+		.map((token) => token.trim())
+		.filter((token) => token.length > 0);
+	if (nonempty.length === 0) return false;
+	return nonempty.every((token) => validatePeruvianPhone(token) || validatePeruvianCci(token));
+}
+
+/** QR payload and/or CCI and/or Yape/Plin phone. A packed rest must be valid typed fields. */
 export function validatePeruvianPaymentId(value: string): boolean {
 	if (!value || typeof value !== "string") return false;
-	const { qr, phone, cci } = parsePeruvianPaymentId(value);
-	return Boolean(qr || phone || cci);
+	const trimmed = value.trim();
+	const sep = trimmed.indexOf(PACKED_PAYMENT_ID_SEP);
+	if (sep >= 0) {
+		const left = trimmed.slice(0, sep);
+		const right = trimmed.slice(sep + PACKED_PAYMENT_ID_SEP.length);
+		const qrOk = validatePeruvianQr(left);
+		if (right.trim()) return qrOk && isValidPeruvianTypedRest(right);
+		return qrOk;
+	}
+	if (validatePeruvianQr(trimmed)) return true;
+	return isValidPeruvianTypedRest(trimmed);
 }
 
 /** Payment ID field configuration for PEN (Peru). At least one of phone / CCI. */

--- a/src/country/currencies/php.ts
+++ b/src/country/currencies/php.ts
@@ -1,4 +1,5 @@
 import { CURRENCY } from "../currency";
+import { isPhilippinePayQr, payQrCandidate } from "../qr-validator";
 import type { CountryOption, PaymentIdFieldConfig } from "../types";
 
 export const PHP_PLACEHOLDER_PHONE = "9171234567";
@@ -80,4 +81,8 @@ export const PHP_COUNTRY_OPTION: CountryOption = {
 	isAlpha: true,
 	disabled: false,
 	disabledPaymentTypes: [],
+	getPayQrPayload: (paymentId) => {
+		const candidate = payQrCandidate(paymentId);
+		return isPhilippinePayQr(candidate) ? candidate : null;
+	},
 };

--- a/src/country/currencies/ven.ts
+++ b/src/country/currencies/ven.ts
@@ -1,5 +1,5 @@
 import { CURRENCY } from "../currency";
-import { validateVenezuelanQr } from "../qr-validator";
+import { isVenezuelanPayQr, payQrCandidate, validateVenezuelanQr } from "../qr-validator";
 import { type CountryOption, PACKED_PAYMENT_ID_SEP, type PaymentIdFieldConfig } from "../types";
 
 export { validateVenezuelanQr };
@@ -152,4 +152,8 @@ export const VEN_COUNTRY_OPTION: CountryOption = {
 	disabledPaymentTypes: [],
 	uploadPaymentQR: true,
 	validateQr: validateVenezuelanQr,
+	getPayQrPayload: (paymentId) => {
+		const candidate = payQrCandidate(paymentId);
+		return isVenezuelanPayQr(candidate) ? candidate : null;
+	},
 };

--- a/src/country/currencies/ven.ts
+++ b/src/country/currencies/ven.ts
@@ -93,11 +93,21 @@ export function serializeVenezuelanPaymentId(
 
 /**
  * Accepts a Suiche 7B QR payload, the typed `phone|rif|bank` fallback,
- * or both packed as `qr||phone|rif|bank`.
+ * or both packed as `qr||phone|rif|bank`. A non-empty packed rest must be a
+ * valid compound — QR does not mask an incomplete trio.
  */
 export function validateVenezuelanPaymentId(value: string): boolean {
 	if (!value || typeof value !== "string") return false;
-	const { qr, compound } = parseVenezuelanPaymentId(value);
+	const trimmed = value.trim();
+	const sep = trimmed.indexOf(PACKED_PAYMENT_ID_SEP);
+	if (sep >= 0) {
+		const left = trimmed.slice(0, sep);
+		const right = trimmed.slice(sep + PACKED_PAYMENT_ID_SEP.length);
+		const qrOk = validateVenezuelanQr(left);
+		if (right.trim()) return qrOk && isValidVenezuelanCompound(right);
+		return qrOk;
+	}
+	const { qr, compound } = parseVenezuelanPaymentId(trimmed);
 	return qr !== null || compound !== null;
 }
 

--- a/src/country/index.ts
+++ b/src/country/index.ts
@@ -25,6 +25,7 @@ export {
 	deserializeCompoundPaymentId,
 	formatCompoundPaymentIdForDisplay,
 	formatStoredPaymentIdForDisplay,
+	getPayQrPayload,
 	getStoredQrPayload,
 	packStoredPaymentId,
 	serializeCompoundPaymentId,

--- a/src/country/index.ts
+++ b/src/country/index.ts
@@ -3,6 +3,7 @@
 export {
 	COUNTRY_OPTIONS,
 	getCountryOption,
+	getTransferWarning,
 	uploadsPaymentQR,
 	usesCatalogPaymentForm,
 	usesPackedPaymentId,

--- a/src/country/index.ts
+++ b/src/country/index.ts
@@ -34,6 +34,7 @@ export {
 	validateArgentinePaymentId,
 	validateBolivianAccount,
 	validateBolivianQr,
+	validateCatalogPaymentDraft,
 	validateColombianPaymentId,
 	validateCubanCardNumber,
 	validateCubanPhoneNumber,

--- a/src/country/qr-validator.ts
+++ b/src/country/qr-validator.ts
@@ -6,8 +6,8 @@
  * call `CountryOption.validateQr` instead of copying peru/ven parsers.
  *
  * This is not `@p2pdotme/sdk/qr-parsers`. Parsers are Scan & Pay: they
- * pull amount/address out of a live scan. Upload is stricter — a bad file
- * must not become the stored payment ID.
+ * pull amount/address out of a live scan. Peru Scan & Pay (`parsePeru`)
+ * reuses `validatePeruvianQr` so a bad CRC cannot become the stored ID.
  *
  * Image → string stays in the apps (`qr-scanner` needs a File / canvas).
  * This module only sees the decoded payload string.
@@ -29,7 +29,8 @@ function crc16ccitt(s: string): string {
 /**
  * Structural EMVCo upload check: parseable TLV, country tag 58, currency tag 53,
  * and a matching CRC-16/CCITT-FALSE (tag 63). CRC is required on upload so we
- * never persist a truncated screenshot.
+ * never persist a truncated screenshot. `getPayQrPayload` may still re-draw a
+ * stored blob whose CRC later fails.
  */
 function validateEmvcoQr(payload: string, country: string, currency: string): boolean {
 	if (!payload || payload.trim().length === 0) return false;
@@ -62,8 +63,8 @@ function validateEmvcoQr(payload: string, country: string, currency: string): bo
 
 /**
  * Yape/Plin EMVCo: country PE, currency 604, CRC-16/CCITT-FALSE.
- * CRC is required on upload so we never persist a truncated screenshot.
- * (PAY render in the merchant is looser; that path does not use this.)
+ * Same rule for SELL upload and Scan & Pay (`parsePeru`).
+ * `getPayQrPayload` may still re-draw a stored blob whose CRC later fails.
  */
 export function validatePeruvianQr(payload: string): boolean {
 	return validateEmvcoQr(payload, "PE", "604");
@@ -104,7 +105,8 @@ export function validateBolivianQr(payload: string): boolean {
  * Suiche 7B / Pago Móvil collection QR: `base64?merchantId=NNNN&…`.
  * The base64 is bank AES — we cannot decode phone/RIF from it, only the
  * envelope. Reject packed `||` IDs so a stored compound string is never
- * treated as a QR. Scan & Pay uses the looser `isPagoMovilQr` envelope.
+ * treated as a QR. Same rule for SELL upload and Scan & Pay (`parsePagoMovil`).
+ * `getPayQrPayload` may still re-draw a stored blob without `merchantId`.
  */
 export function validateVenezuelanQr(payload: string): boolean {
 	if (!payload || typeof payload !== "string") return false;
@@ -115,4 +117,41 @@ export function validateVenezuelanQr(payload: string): boolean {
 	const blob = trimmed.substring(0, qIdx);
 	if (!/^[A-Za-z0-9+/=]+$/.test(blob)) return false;
 	return /(?:^|[?&])merchantId=\d{3,4}(?:&|$)/.test(trimmed.substring(qIdx));
+}
+
+/** Left side of `qr||fields`, or the whole string when not packed. */
+export function payQrCandidate(paymentId: string): string {
+	const trimmed = paymentId.trim();
+	const sep = trimmed.indexOf(PACKED_PAYMENT_ID_SEP);
+	return (sep >= 0 ? trimmed.slice(0, sep) : trimmed).trim();
+}
+
+/**
+ * PAY display: Yape/Plin EMVCo (PE / 604) even when CRC fails.
+ * SELL upload still uses `validatePeruvianQr`.
+ */
+export function isPeruvianPayQr(payload: string): boolean {
+	if (!payload.startsWith("0002")) return false;
+	return payload.includes("5802PE") && payload.includes("5303604");
+}
+
+/**
+ * PAY display: Pago Móvil envelope `base64?…` without requiring merchantId.
+ * SELL upload still uses `validateVenezuelanQr`.
+ */
+export function isVenezuelanPayQr(payload: string): boolean {
+	if (!payload || payload.includes(PACKED_PAYMENT_ID_SEP)) return false;
+	const qIdx = payload.indexOf("?");
+	if (qIdx === -1) return false;
+	const blob = payload.slice(0, qIdx);
+	return blob.length > 0 && /^[A-Za-z0-9+/=]+$/.test(blob);
+}
+
+/**
+ * PAY display: QR Ph EMVCo (PH / 608). SELL PHP is `phone|bank-name`, not a QR.
+ * CRC is not required here — Scan & Pay already gated it on create.
+ */
+export function isPhilippinePayQr(payload: string): boolean {
+	if (!payload.startsWith("0002")) return false;
+	return payload.includes("5802PH") && payload.includes("5303608");
 }

--- a/src/country/qr-validator.ts
+++ b/src/country/qr-validator.ts
@@ -155,3 +155,22 @@ export function isPhilippinePayQr(payload: string): boolean {
 	if (!payload.startsWith("0002")) return false;
 	return payload.includes("5802PH") && payload.includes("5303608");
 }
+
+/**
+ * PAY display: Bolivia QR Simple. EMVCo (BO / 068) even when CRC fails, or an
+ * encrypted envelope `<base64>|<hex>` with a looser checksum than SELL upload
+ * (16–64 hex vs 24/32). SELL still uses `validateBolivianQr`.
+ */
+export function isBolivianPayQr(payload: string): boolean {
+	if (!payload || payload.includes(PACKED_PAYMENT_ID_SEP)) return false;
+	if (payload.startsWith("0002") && payload.includes("5802BO") && payload.includes("5303068")) {
+		return true;
+	}
+	const sep = payload.lastIndexOf("|");
+	if (sep < 40) return false;
+	const blob = payload.slice(0, sep);
+	const tag = payload.slice(sep + 1);
+	if (blob.length % 4 !== 0) return false;
+	if (!/^[A-Za-z0-9+/]+={0,2}$/.test(blob)) return false;
+	return /^[0-9A-Fa-f]{16,64}$/.test(tag);
+}

--- a/src/country/types.ts
+++ b/src/country/types.ts
@@ -57,4 +57,10 @@ export interface CountryOption {
 	 * Only used when the typed fallback did not already set the key.
 	 */
 	readonly hydrateFieldsFromQr?: (qr: string) => Partial<Record<string, string>>;
+	/**
+	 * i18n key for a warning shown before the payer sends fiat (e.g. a bank
+	 * outage). Apps call `getTransferWarning(currency)` — do not branch on
+	 * currency. Omit when there is no warning.
+	 */
+	readonly transferWarning?: string;
 }

--- a/src/country/types.ts
+++ b/src/country/types.ts
@@ -45,6 +45,14 @@ export interface CountryOption {
 	/** Structural check for a standalone QR payload (no `||` pack). */
 	readonly validateQr?: (payload: string) => boolean;
 	/**
+	 * PAY display: payload to re-draw a stored QR. May be looser than
+	 * `validateQr` so old orders still render (e.g. Yape/Plin without CRC,
+	 * Pago Móvil without `merchantId`). Scan & Pay uses `validateQr` /
+	 * parsers, not this hook. Apps call `getPayQrPayload(currency, id)` —
+	 * do not branch on currency.
+	 */
+	readonly getPayQrPayload?: (paymentId: string) => string | null;
+	/**
 	 * Fill catalog fields from a validated QR (e.g. Yape/Plin phone in EMVCo).
 	 * Only used when the typed fallback did not already set the key.
 	 */

--- a/src/country/validators.ts
+++ b/src/country/validators.ts
@@ -28,7 +28,15 @@ export {
 	validateVenezuelanPhoneNumber,
 	validateVenezuelanRif,
 } from "./currencies";
-export { validateBolivianQr, validatePeruvianQr, validateVenezuelanQr } from "./qr-validator";
+export {
+	isPeruvianPayQr,
+	isPhilippinePayQr,
+	isVenezuelanPayQr,
+	payQrCandidate,
+	validateBolivianQr,
+	validatePeruvianQr,
+	validateVenezuelanQr,
+} from "./qr-validator";
 export { PACKED_PAYMENT_ID_SEP };
 
 /** Serializes multiple fields into a pipe-separated string. */
@@ -171,6 +179,20 @@ export function getStoredQrPayload(
 	return null;
 }
 
+/**
+ * Payload to feed `QRCodeSVG` for a PAY (or packed SELL) order.
+ * Tries strict `getStoredQrPayload` first, then the country's PAY hook.
+ */
+export function getPayQrPayload(
+	currency: CurrencyCode | null | undefined,
+	paymentId: string | null | undefined,
+): string | null {
+	if (!currency || !paymentId) return null;
+	const stored = getStoredQrPayload(currency, paymentId);
+	if (stored) return stored;
+	return getCountryOption(currency)?.getPayQrPayload?.(paymentId.trim()) ?? null;
+}
+
 function packedTypedRest(
 	fields: readonly PaymentIdFieldConfig[],
 	fieldValues: Record<string, string>,
@@ -252,6 +274,12 @@ export function assignStoredPaymentIdToFieldValues(
 	} else if (isStandaloneQr(option?.validateQr, trimmed)) {
 		qrPayload = trimmed;
 		typed = "";
+	} else {
+		const payQr = option?.getPayQrPayload?.(trimmed);
+		if (payQr) {
+			qrPayload = payQr;
+			typed = qr && payQr === qr ? rest.trim() : "";
+		}
 	}
 
 	const values = assignPaymentIdToFieldValues(fields, typed);

--- a/src/country/validators.ts
+++ b/src/country/validators.ts
@@ -29,6 +29,7 @@ export {
 	validateVenezuelanRif,
 } from "./currencies";
 export {
+	isBolivianPayQr,
 	isPeruvianPayQr,
 	isPhilippinePayQr,
 	isVenezuelanPayQr,

--- a/src/country/validators.ts
+++ b/src/country/validators.ts
@@ -198,11 +198,7 @@ function packedTypedRest(
 	fields: readonly PaymentIdFieldConfig[],
 	fieldValues: Record<string, string>,
 ): string {
-	const parts = fields.map((field) => {
-		const value = (fieldValues[field.key] ?? "").trim();
-		if (!value) return "";
-		return field.validate(value) ? value : "";
-	});
+	const parts = fields.map((field) => (fieldValues[field.key] ?? "").trim());
 	if (!parts.some((part) => part.length > 0)) return "";
 	return serializeCompoundPaymentId(...parts);
 }
@@ -227,11 +223,26 @@ export function packStoredPaymentId(
 function fieldsMatchStoredId(fields: readonly PaymentIdFieldConfig[], paymentId: string): boolean {
 	if (validatePaymentIdFields(fields, paymentId)) return true;
 	const assigned = assignPaymentIdToFieldValues(fields, paymentId);
-	const filled = fields.filter((field) => (assigned[field.key] || "").trim().length > 0);
-	if (filled.length === 0) return false;
-	return fields.every(
-		(field) => field.optional === true || (assigned[field.key] || "").trim().length > 0,
-	);
+	const values = fields.map((field) => (assigned[field.key] || "").trim());
+	if (!values.some((value) => value.length > 0)) return false;
+	return fields.every((field, i) => {
+		const value = values[i];
+		if (!value) return field.optional === true;
+		return field.validate(value);
+	});
+}
+
+/**
+ * Catalog payment form draft: optional QR and/or typed fields may coexist.
+ * Neither path is required relative to the other. If any typed field has text,
+ * non-optional fields must all be present and valid (`optional` on the catalog).
+ */
+export function validateCatalogPaymentDraft(
+	currency: CurrencyCode,
+	qr: string | null | undefined,
+	fieldValues: Record<string, string>,
+): boolean {
+	return validateStoredPaymentId(currency, packStoredPaymentId(currency, qr, fieldValues));
 }
 
 /**

--- a/src/qr-parsers/README.md
+++ b/src/qr-parsers/README.md
@@ -62,12 +62,12 @@ The proxy receives `GET /pix?locationUrl=<url>&orderId=<id>` and should return t
 
 ### Pago Móvil (VEN)
 
-Scan & pay stores the **full** scanned string (`base64?merchantId=…` or `base64?bank=…`) as `paymentAddress`. The merchant re-encodes that same blob with `QRCodeSVG` — do not unpack it as SELL `phone|rif|bank`. Use `isPagoMovilQr` to detect the envelope; SELL upload uses the stricter `validateVenezuelanQr` (minimum blob length + `merchantId`).
+Scan & pay stores the **full** scanned string (`base64?merchantId=NNNN&…`) as `paymentAddress`. Same envelope as SELL upload (`validateVenezuelanQr`: blob ≥ 40 + `merchantId`). The merchant re-encodes that blob with `getPayQrPayload` / `QRCodeSVG` — do not unpack it as SELL `phone|rif|bank`. `getPayQrPayload` may still re-draw an older stored blob without `merchantId`.
 
 ```ts
 import { isPagoMovilQr } from "@p2pdotme/sdk/qr-parsers";
 
-isPagoMovilQr(scanned); // true → QRCodeSVG value={scanned}
+isPagoMovilQr(scanned); // same as validateVenezuelanQr
 ```
 
 ### Transfermóvil (CUP)

--- a/src/qr-parsers/parse-qr.ts
+++ b/src/qr-parsers/parse-qr.ts
@@ -1,4 +1,4 @@
-import { CURRENCY } from "../country";
+import { CURRENCY, getCountryOption } from "../country";
 import { parseMercadoPago } from "./parsers/ars";
 import { parseBolivia } from "./parsers/bob";
 import { parsePIX } from "./parsers/brl";
@@ -23,6 +23,9 @@ import { failure } from "./types";
  * a signed JWT whose `valor.original` field holds the amount. All other parsers
  * (UPI, QRIS, QR Ph, MercadoPago, PagoMovil, Transfermóvil) and static PIX are synchronous and
  * resolve immediately.
+ *
+ * When the country has `validateQr` (PEN, VEN, BOB), Scan & Pay must pass the
+ * same check as SELL upload — not a looser envelope.
  */
 export async function parseQR(params: ParseQRParams): Promise<ParseResult> {
 	const { qrData, currency, sellPrice, proxyUrl, orderId } = params;
@@ -31,32 +34,52 @@ export async function parseQR(params: ParseQRParams): Promise<ParseResult> {
 		return failure("INVALID_QR", "QR data is empty or invalid");
 	}
 
+	let result: ParseResult;
 	switch (currency) {
 		case CURRENCY.INR:
-			return parseUPI(qrData, sellPrice);
+			result = parseUPI(qrData, sellPrice);
+			break;
 		case CURRENCY.IDR:
-			return parseQRIS(qrData, sellPrice);
+			result = parseQRIS(qrData, sellPrice);
+			break;
 		case CURRENCY.BRL:
-			return parsePIX(qrData, sellPrice, { proxyUrl, orderId });
+			result = await parsePIX(qrData, sellPrice, { proxyUrl, orderId });
+			break;
 		case CURRENCY.ARS:
-			return parseMercadoPago(qrData, sellPrice);
+			result = parseMercadoPago(qrData, sellPrice);
+			break;
 		case CURRENCY.VEN:
-			return parsePagoMovil(qrData, sellPrice);
+			result = parsePagoMovil(qrData, sellPrice);
+			break;
 		case CURRENCY.BOB:
-			return parseBolivia(qrData, sellPrice);
+			result = parseBolivia(qrData, sellPrice);
+			break;
 		case CURRENCY.NGN:
-			return parseNGN(qrData, sellPrice);
+			result = parseNGN(qrData, sellPrice);
+			break;
 		case CURRENCY.COP:
-			return parseCOP(qrData, sellPrice);
+			result = parseCOP(qrData, sellPrice);
+			break;
 		case CURRENCY.CUP:
-			return parseTransfermovil(qrData, sellPrice);
+			result = parseTransfermovil(qrData, sellPrice);
+			break;
 		case CURRENCY.ECU:
-			return parseDeUna(qrData, sellPrice);
+			result = parseDeUna(qrData, sellPrice);
+			break;
 		case CURRENCY.PEN:
-			return parsePeru(qrData, sellPrice);
+			result = parsePeru(qrData, sellPrice);
+			break;
 		case CURRENCY.PHP:
-			return parseQRPh(qrData, sellPrice);
+			result = parseQRPh(qrData, sellPrice);
+			break;
 		default:
 			return failure("INVALID_CURRENCY", `Currency "${currency}" is not supported`);
 	}
+
+	const validateQr = getCountryOption(currency)?.validateQr;
+	if (result.isOk() && validateQr && !validateQr(qrData.trim())) {
+		return failure("INVALID_QR", "QR does not match catalog validateQr");
+	}
+
+	return result;
 }

--- a/src/qr-parsers/parsers/pen.ts
+++ b/src/qr-parsers/parsers/pen.ts
@@ -1,15 +1,17 @@
+import { validatePeruvianQr } from "../../country/qr-validator";
 import type { ParsedQR, ParseResult } from "../types";
 import { failure, success } from "../types";
 import { parseAmount } from "../utils/amount";
 import { extractTags } from "../utils/tlv";
 
-const PEN_TAGS = { AMOUNT: "54", CURRENCY: "53", COUNTRY: "58" } as const;
+const PEN_TAGS = { AMOUNT: "54" } as const;
 
 /**
- * Parses a Peruvian Yape/Plin EMVCo QR. Validates it is a genuine Peru QR
- * (country tag 58 `PE`, currency tag 53 `604`) and returns the raw payload verbatim
- * as `paymentAddress` so the buyer app can re-render the exact QR. Static QRs carry
- * no amount; when tag 54 is present it is converted to usdc via `sellPrice`.
+ * Parses a Peruvian Yape/Plin EMVCo QR. Uses the same structural + CRC check
+ * as SELL upload (`validatePeruvianQr`: country PE, currency 604, CRC-16).
+ * Returns the raw payload verbatim as `paymentAddress` so the merchant can
+ * re-render the exact QR. Static QRs carry no amount; tag 54 converts via
+ * `sellPrice`.
  */
 export function parsePeru(qrData: string, sellPrice: number): ParseResult {
 	if (!qrData || typeof qrData !== "string" || qrData.trim().length === 0) {
@@ -17,12 +19,11 @@ export function parsePeru(qrData: string, sellPrice: number): ParseResult {
 	}
 
 	const trimmed = qrData.trim();
-	const tags = extractTags(trimmed, [PEN_TAGS.AMOUNT, PEN_TAGS.CURRENCY, PEN_TAGS.COUNTRY]);
-
-	if (tags[PEN_TAGS.COUNTRY] !== "PE" || tags[PEN_TAGS.CURRENCY] !== "604") {
+	if (!validatePeruvianQr(trimmed)) {
 		return failure("INVALID_QR", "Not a valid Peru Yape/Plin QR");
 	}
 
+	const tags = extractTags(trimmed, [PEN_TAGS.AMOUNT]);
 	const result: ParsedQR = { paymentAddress: trimmed };
 
 	const amountStr = tags[PEN_TAGS.AMOUNT];

--- a/src/qr-parsers/parsers/ven.ts
+++ b/src/qr-parsers/parsers/ven.ts
@@ -1,31 +1,28 @@
+import { validateVenezuelanQr } from "../../country/qr-validator";
 import type { ParseResult } from "../types";
 import { failure, success } from "../types";
 
 /**
- * Envelope check for a Pago Móvil / Suiche 7B scan: opaque `base64?…`.
- * PAY stores this whole string as the payment ID so the merchant can
- * re-encode it as a QR. Stricter SELL upload rules live in `validateVenezuelanQr`.
+ * Same envelope as SELL upload: opaque `base64?merchantId=NNNN` (blob ≥ 40).
+ * Prefer `validateVenezuelanQr` from `@p2pdotme/sdk/country`; this alias stays
+ * for `@p2pdotme/sdk/qr-parsers` callers.
  */
 export function isPagoMovilQr(qrData: string): boolean {
-	if (!qrData || typeof qrData !== "string" || qrData.trim().length === 0) {
-		return false;
-	}
-
-	const trimmed = qrData.trim();
-	const qIdx = trimmed.indexOf("?");
-	if (qIdx === -1) return false;
-
-	const payload = trimmed.substring(0, qIdx);
-	return !!payload && /^[A-Za-z0-9+/=]+$/.test(payload);
+	return validateVenezuelanQr(qrData);
 }
 
+/**
+ * Parses a Venezuelan Pago Móvil / Suiche 7B QR. Uses the same envelope as
+ * SELL upload (`validateVenezuelanQr`). Returns the raw payload verbatim as
+ * `paymentAddress` so the merchant can re-render the exact QR.
+ */
 export function parsePagoMovil(qrData: string, _sellPrice: number): ParseResult {
 	if (!qrData || typeof qrData !== "string" || qrData.trim().length === 0) {
 		return failure("INVALID_QR", "QR data is empty or invalid");
 	}
 
 	const trimmed = qrData.trim();
-	if (!isPagoMovilQr(trimmed)) {
+	if (!validateVenezuelanQr(trimmed)) {
 		return failure("INVALID_QR", "Not a valid Venezuelan QR code");
 	}
 

--- a/test/country/pay-qr-payload.test.ts
+++ b/test/country/pay-qr-payload.test.ts
@@ -48,6 +48,18 @@ describe("getPayQrPayload", () => {
 		expect(getPayQrPayload("VEN", VEN_COMPOUND)).toBeNull();
 	});
 
+	it("returns a BOB PAY blob, including EMVCo whose CRC fails validateQr", () => {
+		const bobEmvco =
+			"00020101021153030685802BO5906TIENDA6304ABCD";
+		const bobBadCrc = bobEmvco.replace("6304ABCD", "6304FFFF");
+		const bobEnvelope =
+			"rqeunYVqZLSBH9wP9g9edc2eo8ywIMBYO4Hp6zkL7K/lvplzVgpBfA7UA7nH6aNP7wnaDJe41h4YBHYVo8VCaYpigvLPxmRdbIrykn2IFuJUi+2fCfY2Do7EtQU11c8JyZ0C1L5KRe5I4E59r9zeghuVQUUNtgaSsZS+mqqVQ5z0EDqo21xVmLjD3PWVY/4LJpz9Cn8aFSwGPVk7fUd9SUpCGV812+IK9K1fE2okI+rtKmyWANBFWCUyz3EE2pvoRjMh6EosPnGzU1cRDapU0ZcOnsZAryOrXQz7d0WM/rn6OHm5rW+a5OVt93YqOqfNLXW2VYQPVbTg85+UlkQIpw==|07F204D5938E28075E5BF22340391EE1";
+		expect(getPayQrPayload("BOB", bobEnvelope)).toBe(bobEnvelope);
+		expect(getStoredQrPayload("BOB", bobBadCrc)).toBeNull();
+		expect(getPayQrPayload("BOB", bobBadCrc)).toBe(bobBadCrc);
+		expect(getPayQrPayload("BOB", "12345678901")).toBeNull();
+	});
+
 	it("returns a PHP QR Ph blob and ignores InstaPay phone|bank", () => {
 		expect(getStoredQrPayload("PHP", PHP_QR)).toBeNull();
 		expect(getPayQrPayload("PHP", PHP_QR)).toBe(PHP_QR);

--- a/test/country/pay-qr-payload.test.ts
+++ b/test/country/pay-qr-payload.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+	assignStoredPaymentIdToFieldValues,
+	formatStoredPaymentIdForDisplay,
+	getPayQrPayload,
+	getStoredQrPayload,
+	PACKED_PAYMENT_ID_SEP,
+} from "../../src/country";
+
+const PEN_QR =
+	"0002010102113932acfba6cb922753c690f09280f365d7a25204561153036045802PE5906YAPERO6004Lima6304ECE9";
+const PEN_BAD_CRC = PEN_QR.replace("6304ECE9", "6304FFFF");
+const PHP_QR =
+	"00020101021127830012com.p2pqrpay0111GXCHPHM2XXX02081234567803150000000000000000417TESTTESTTESTTEST15204601653036085802PH5909TEST SHOP6006Manila61041000630476A9";
+const VEN_PAY =
+	"dBKxwilNo3+ATaUX7YpeGfb+DOGtIBnj2DpAypb7U6gqar/JxjhLFaXIKyv9O+Z6xh3rX2B6huFupypAZjcj0istG7bYvJ5XO3NfqXYAeVR+hEwkuuBBcCy+9MKH7OJMvDGEXU143a7+bgcrTjaCzQ==?merchantId=0163&strong_id=1786921164-3";
+const VEN_LOOSE = "SGVsbG9Xb3JsZA==?param=1";
+const VEN_COMPOUND = "04121234567|V12345678|Banesco";
+const PHP_COMPOUND = "9171234567|GCash";
+const PEN_PHONE = "987654321";
+
+describe("getPayQrPayload", () => {
+	it("returns a valid PEN upload QR via getStoredQrPayload first", () => {
+		expect(getStoredQrPayload("PEN", PEN_QR)).toBe(PEN_QR);
+		expect(getPayQrPayload("PEN", PEN_QR)).toBe(PEN_QR);
+	});
+
+	it("returns a PEN PAY blob whose CRC fails validateQr", () => {
+		expect(getStoredQrPayload("PEN", PEN_BAD_CRC)).toBeNull();
+		expect(getPayQrPayload("PEN", PEN_BAD_CRC)).toBe(PEN_BAD_CRC);
+		expect(getPayQrPayload("PEN", `${PEN_BAD_CRC}${PACKED_PAYMENT_ID_SEP}${PEN_PHONE}`)).toBe(
+			PEN_BAD_CRC,
+		);
+	});
+
+	it("does not treat a PEN phone or CCI as a QR", () => {
+		expect(getPayQrPayload("PEN", PEN_PHONE)).toBeNull();
+		expect(getPayQrPayload("PEN", "00212345678901234567")).toBeNull();
+	});
+
+	it("returns a VEN PAY envelope, including ones that fail SELL validateQr", () => {
+		expect(getPayQrPayload("VEN", VEN_PAY)).toBe(VEN_PAY);
+		expect(getStoredQrPayload("VEN", VEN_LOOSE)).toBeNull();
+		expect(getPayQrPayload("VEN", VEN_LOOSE)).toBe(VEN_LOOSE);
+	});
+
+	it("does not treat a VEN compound phone|rif|bank as a QR", () => {
+		expect(getPayQrPayload("VEN", VEN_COMPOUND)).toBeNull();
+	});
+
+	it("returns a PHP QR Ph blob and ignores InstaPay phone|bank", () => {
+		expect(getStoredQrPayload("PHP", PHP_QR)).toBeNull();
+		expect(getPayQrPayload("PHP", PHP_QR)).toBe(PHP_QR);
+		expect(getPayQrPayload("PHP", PHP_COMPOUND)).toBeNull();
+	});
+
+	it("does not dump a PHP PAY blob into Phone Number / Bank Name", () => {
+		expect(assignStoredPaymentIdToFieldValues("PHP", PHP_QR)).toEqual({
+			phone: "",
+			"bank-name": "",
+		});
+		expect(formatStoredPaymentIdForDisplay("PHP", PHP_QR)).toBe("");
+		expect(assignStoredPaymentIdToFieldValues("PHP", PHP_COMPOUND)).toEqual({
+			phone: "9171234567",
+			"bank-name": "GCash",
+		});
+	});
+});

--- a/test/country/transfer-warning.test.ts
+++ b/test/country/transfer-warning.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { COUNTRY_OPTIONS, getTransferWarning } from "../../src/country/countries";
+import { CUP_COUNTRY_OPTION } from "../../src/country/currencies/cup";
+
+describe("getTransferWarning", () => {
+	it("returns the CUP i18n key and nothing else", () => {
+		expect(CUP_COUNTRY_OPTION.transferWarning).toBe("CUP_BANDEC_WARNING");
+		expect(COUNTRY_OPTIONS.filter((c) => c.transferWarning).map((c) => c.currency)).toEqual([
+			"CUP",
+		]);
+	});
+
+	it("reads the key from COUNTRY_OPTIONS", () => {
+		expect(getTransferWarning("CUP")).toBe("CUP_BANDEC_WARNING");
+		expect(getTransferWarning("INR")).toBeNull();
+		expect(getTransferWarning("BRL")).toBeNull();
+		expect(getTransferWarning(null)).toBeNull();
+	});
+});

--- a/test/country/validators.test.ts
+++ b/test/country/validators.test.ts
@@ -33,6 +33,7 @@ import {
 	getStoredQrPayload,
 	PACKED_PAYMENT_ID_SEP,
 	packStoredPaymentId,
+	validateCatalogPaymentDraft,
 	validatePaymentIdFields,
 	validateStoredPaymentId,
 } from "../../src/country/validators";
@@ -307,6 +308,15 @@ describe("validateVenezuelanPaymentId (VEN QR or compound)", () => {
 		expect(
 			validateVenezuelanPaymentId(`${qr}||04121234567|V12345678|Banesco`),
 		).toBe(true);
+	});
+
+	it("rejects a packed QR with an incomplete typed rest", () => {
+		const qr = `${"A".repeat(48)}?merchantId=0134&origin=app`;
+		expect(validateVenezuelanPaymentId(`${qr}||04121234567`)).toBe(false);
+		expect(validateVenezuelanPaymentId(`${qr}||04121234567||`)).toBe(false);
+		expect(validateVenezuelanPaymentId(`${qr}||04121234567|V12345678|`)).toBe(
+			false,
+		);
 	});
 
 	it("does not treat a packed id as a raw QR payload", () => {
@@ -633,6 +643,9 @@ describe("parse/serialize Peruvian packed payment ID", () => {
 		expect(validatePeruvianPaymentId(SAMPLE)).toBe(true);
 		expect(validatePeruvianPaymentId(`${SAMPLE}${PACKED_PAYMENT_ID_SEP}${PHONE}`)).toBe(true);
 		expect(validatePeruvianPaymentId("")).toBe(false);
+		expect(validatePeruvianPaymentId(`${SAMPLE}${PACKED_PAYMENT_ID_SEP}12`)).toBe(
+			false,
+		);
 	});
 
 	it("validateStoredPaymentId / display / hydrate go through the catalog", () => {
@@ -682,6 +695,15 @@ describe("parse/serialize Peruvian packed payment ID", () => {
 		expect(packStoredPaymentId("PEN", SAMPLE, { phone: PHONE, cci: "" })).toBe(
 			`${SAMPLE}${PACKED_PAYMENT_ID_SEP}${PHONE}|`,
 		);
+		expect(packStoredPaymentId("PEN", SAMPLE, { phone: "12", cci: "" })).toBe(
+			`${SAMPLE}${PACKED_PAYMENT_ID_SEP}12|`,
+		);
+		expect(
+			validateStoredPaymentId(
+				"PEN",
+				packStoredPaymentId("PEN", SAMPLE, { phone: "12", cci: "" }),
+			),
+		).toBe(false);
 		expect(packStoredPaymentId("PEN", null, { phone: PHONE, cci: "" })).toBe(`${PHONE}|`);
 		expect(getStoredQrPayload("PEN", SAMPLE)).toBe(SAMPLE);
 		expect(getStoredQrPayload("PEN", `${SAMPLE}${PACKED_PAYMENT_ID_SEP}${PHONE}`)).toBe(SAMPLE);
@@ -696,6 +718,23 @@ describe("parse/serialize Peruvian packed payment ID", () => {
 				bank: "Banesco",
 			}),
 		).toBe(`${venQr}||04121234567|V12345678|Banesco`);
+		expect(
+			packStoredPaymentId("VEN", venQr, {
+				phone: "04121234567",
+				rif: "",
+				bank: "",
+			}),
+		).toBe(`${venQr}||04121234567||`);
+		expect(
+			validateStoredPaymentId(
+				"VEN",
+				packStoredPaymentId("VEN", venQr, {
+					phone: "04121234567",
+					rif: "",
+					bank: "",
+				}),
+			),
+		).toBe(false);
 		expect(getStoredQrPayload("VEN", venQr)).toBe(venQr);
 		expect(getStoredQrPayload("VEN", "04121234567|V12345678|Banesco")).toBeNull();
 	});
@@ -941,6 +980,12 @@ describe("BOB stored payment id (QR upload + account)", () => {
 		expect(packStoredPaymentId("BOB", QR, { account: ACCOUNT })).toBe(
 			`${QR}${PACKED_PAYMENT_ID_SEP}${ACCOUNT}`,
 		);
+		expect(packStoredPaymentId("BOB", QR, { account: "12" })).toBe(
+			`${QR}${PACKED_PAYMENT_ID_SEP}12`,
+		);
+		expect(
+			validateStoredPaymentId("BOB", packStoredPaymentId("BOB", QR, { account: "12" })),
+		).toBe(false);
 		expect(packStoredPaymentId("BOB", null, { account: ACCOUNT })).toBe(ACCOUNT);
 		expect(getStoredQrPayload("BOB", QR)).toBe(QR);
 		expect(getStoredQrPayload("BOB", `${QR}${PACKED_PAYMENT_ID_SEP}${ACCOUNT}`)).toBe(QR);
@@ -953,5 +998,65 @@ describe("BOB stored payment id (QR upload + account)", () => {
 		expect(assignStoredPaymentIdToFieldValues("BOB", `${QR}${PACKED_PAYMENT_ID_SEP}${ACCOUNT}`)).toEqual(
 			{ account: ACCOUNT },
 		);
+	});
+});
+
+describe("validateCatalogPaymentDraft", () => {
+	const venQr = `${"A".repeat(48)}?merchantId=0134&origin=app`;
+	const venFields = {
+		phone: "04121234567",
+		rif: "V12345678",
+		bank: "Banesco",
+	};
+
+	it("accepts QR-only, typed-only, or both for VEN", () => {
+		expect(validateCatalogPaymentDraft("VEN", venQr, { phone: "", rif: "", bank: "" })).toBe(
+			true,
+		);
+		expect(validateCatalogPaymentDraft("VEN", null, venFields)).toBe(true);
+		expect(validateCatalogPaymentDraft("VEN", venQr, venFields)).toBe(true);
+	});
+
+	it("rejects an empty draft and a partial typed trio", () => {
+		expect(validateCatalogPaymentDraft("VEN", null, { phone: "", rif: "", bank: "" })).toBe(
+			false,
+		);
+		expect(
+			validateCatalogPaymentDraft("VEN", venQr, {
+				phone: "04121234567",
+				rif: "",
+				bank: "",
+			}),
+		).toBe(false);
+		expect(
+			validateCatalogPaymentDraft("VEN", null, {
+				phone: "04121234567",
+				rif: "",
+				bank: "",
+			}),
+		).toBe(false);
+	});
+
+	it("accepts PEN QR-only and rejects QR plus an invalid phone", () => {
+		const penQr =
+			"0002010102113932acfba6cb922753c690f09280f365d7a25204561153036045802PE5906YAPERO6004Lima6304ECE9";
+		expect(validateCatalogPaymentDraft("PEN", penQr, { phone: "", cci: "" })).toBe(true);
+		expect(validateCatalogPaymentDraft("PEN", penQr, { phone: "987654321", cci: "" })).toBe(
+			true,
+		);
+		expect(validateCatalogPaymentDraft("PEN", penQr, { phone: "12", cci: "" })).toBe(false);
+		expect(validateCatalogPaymentDraft("PEN", null, { phone: "12", cci: "" })).toBe(false);
+	});
+
+	it("accepts BOB QR-only and rejects QR plus a short account", () => {
+		function tlv(tag: string, value: string): string {
+			return `${tag}${value.length.toString().padStart(2, "0")}${value}`;
+		}
+		const inner = `000201${tlv("53", "068")}${tlv("58", "BO")}${tlv("59", "TIENDA")}`;
+		const bobQr = `${inner}6304${calculateCRC16(inner)}`;
+		expect(validateCatalogPaymentDraft("BOB", bobQr, { account: "" })).toBe(true);
+		expect(validateCatalogPaymentDraft("BOB", bobQr, { account: "12345678901" })).toBe(true);
+		expect(validateCatalogPaymentDraft("BOB", bobQr, { account: "12" })).toBe(false);
+		expect(validateCatalogPaymentDraft("BOB", null, { account: "12" })).toBe(false);
 	});
 });

--- a/test/qr-parsers/parse-qr.test.ts
+++ b/test/qr-parsers/parse-qr.test.ts
@@ -49,10 +49,20 @@ describe("parseQR dispatcher", () => {
 	});
 
 	it("dispatches VEN to PagoMovil parser", async () => {
-		const data = unwrap(
-			await parseQR({ qrData: "SGVsbG8=?x=1", currency: "VEN", sellPrice: 40 }),
-		);
-		expect(data.paymentAddress).toBe("SGVsbG8=?x=1");
+		const sample =
+			"dBKxwilNo3+ATaUX7YpeGfb+DOGtIBnj2DpAypb7U6gqar/JxjhLFaXIKyv9O+Z6xh3rX2B6huFupypAZjcj0istG7bYvJ5XO3NfqXYAeVR+hEwkuuBBcCy+9MKH7OJMvDGEXU143a7+bgcrTjaCzQ==?merchantId=0163&strong_id=1786921164-3";
+		const data = unwrap(await parseQR({ qrData: sample, currency: "VEN", sellPrice: 40 }));
+		expect(data.paymentAddress).toBe(sample);
+	});
+
+	it("rejects a VEN envelope that fails catalog validateQr (no merchantId)", async () => {
+		const result = await parseQR({
+			qrData: "SGVsbG9Xb3JsZA==?param=1",
+			currency: "VEN",
+			sellPrice: 40,
+		});
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) expect(result.error.code).toBe("INVALID_QR");
 	});
 
 	it("dispatches BOB to the Bolivia parser", async () => {

--- a/test/qr-parsers/pen.test.ts
+++ b/test/qr-parsers/pen.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { parsePeru } from "../../src/qr-parsers/parsers/pen";
+import { calculateCRC16 } from "../../src/qr-parsers/utils/crc16";
 
 const SELL_PRICE = 3.75;
 
@@ -9,6 +10,10 @@ const SAMPLE =
 
 function tlv(tag: string, value: string): string {
 	return `${tag}${value.length.toString().padStart(2, "0")}${value}`;
+}
+
+function withCRC(data: string): string {
+	return `${data}6304${calculateCRC16(data)}`;
 }
 
 function unwrap<T, E>(r: { isOk(): boolean; isErr(): boolean; value?: T; error?: E }) {
@@ -24,7 +29,9 @@ describe("parsePeru (PEN)", () => {
 	});
 
 	it("parses an amount (tag 54) and converts to usdc", () => {
-		const withAmount = `000201${tlv("53", "604")}${tlv("54", "1500")}${tlv("58", "PE")}${tlv("59", "YAPERO")}`;
+		const withAmount = withCRC(
+			`000201${tlv("53", "604")}${tlv("54", "1500")}${tlv("58", "PE")}${tlv("59", "YAPERO")}`,
+		);
 		const data = unwrap(parsePeru(withAmount, SELL_PRICE));
 		expect(data.paymentAddress).toBe(withAmount);
 		expect(data.amount).toEqual({ fiat: 1500, usdc: 1500 / SELL_PRICE });
@@ -42,6 +49,13 @@ describe("parsePeru (PEN)", () => {
 	it("returns INVALID_QR for a non-Peru currency (tag 53 not 604)", () => {
 		const tweaked = SAMPLE.replace("5303604", "5303840");
 		const result = parsePeru(tweaked, SELL_PRICE);
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) expect(result.error.code).toBe("INVALID_QR");
+	});
+
+	it("returns INVALID_QR when CRC does not match (same rule as SELL upload)", () => {
+		const corrupted = SAMPLE.replace("6304ECE9", "6304FFFF");
+		const result = parsePeru(corrupted, SELL_PRICE);
 		expect(result.isErr()).toBe(true);
 		if (result.isErr()) expect(result.error.code).toBe("INVALID_QR");
 	});

--- a/test/qr-parsers/ven.test.ts
+++ b/test/qr-parsers/ven.test.ts
@@ -1,45 +1,43 @@
 import { describe, expect, it } from "vitest";
 import { isPagoMovilQr, parsePagoMovil } from "../../src/qr-parsers/parsers/ven";
 
+const TESORO =
+	"dBKxwilNo3+ATaUX7YpeGfb+DOGtIBnj2DpAypb7U6gqar/JxjhLFaXIKyv9O+Z6xh3rX2B6huFupypAZjcj0istG7bYvJ5XO3NfqXYAeVR+hEwkuuBBcCy+9MKH7OJMvDGEXU143a7+bgcrTjaCzQ==?merchantId=0163&strong_id=1786921164-3";
+const MERCANTIL =
+	"m28tuwbizhMer7LqTrXDR390LJYTLTMLxvAojSnPrZ2ese+vGGypN/1IfjBJVQyduC5qN+Hvyqa8FzYoP1xntmkI7PU6HlnAEpYgEZ1TSahnec0Ctt1Tpg3gK3rTG0ay5ST8h24YHsc6Q4aZtmxdLjtKyeChlbRhqq6v8e9qNlrpc/2nZ6HV0a1mcIOz7qm4GgpPQMaHW5ywzkuWE0ps9fMB9kCiyGPNj6G0SZomROybsNlMDevCMdpbGyz5w84MxNdomJwEgy8qhBYgKSEPlCn/cCmAdeZCtyFypu6Tr1tDgrlL0kLNRrv2CQKkLw3uHx8zxZohwuu3Cau0io4elA==?merchantId=0105&strong_id=260722171116&origin=web";
+
 function unwrap<T, E>(r: { isOk(): boolean; isErr(): boolean; value?: T; error?: E }) {
 	if (r.isErr()) throw new Error(`expected ok, got err: ${String(r.error)}`);
 	return r.value as T;
 }
 
-describe("isPagoMovilQr (VEN PAY envelope)", () => {
-	it("accepts a base64 blob plus query, including live bank QRs without going through SELL validateQr", () => {
-		expect(isPagoMovilQr("SGVsbG9Xb3JsZA==?param=1")).toBe(true);
-		expect(
-			isPagoMovilQr(
-				`${"dGhlIHZlbmV6dWVsYW4gcXIgaXMgYSBiYXNlNjQgZW5jcnlwdGVkIHN0cmluZyB0aGF0IG9ubHkgYmFua3MgY2FuIGRlY2lwaGVy"}?bank=BANCO_A`,
-			),
-		).toBe(true);
-		expect(
-			isPagoMovilQr(
-				"dBKxwilNo3+ATaUX7YpeGfb+DOGtIBnj2DpAypb7U6gqar/JxjhLFaXIKyv9O+Z6xh3rX2B6huFupypAZjcj0istG7bYvJ5XO3NfqXYAeVR+hEwkuuBBcCy+9MKH7OJMvDGEXU143a7+bgcrTjaCzQ==?merchantId=0163&strong_id=1786921164-3",
-			),
-		).toBe(true);
+describe("isPagoMovilQr (VEN)", () => {
+	it("accepts live S7B QRs with merchantId (same rule as SELL validateQr)", () => {
+		expect(isPagoMovilQr(TESORO)).toBe(true);
+		expect(isPagoMovilQr(MERCANTIL)).toBe(true);
 	});
 
-	it.each(["", "SGVsbG8=", "not base64!@#?x=y", "?x=y"])(
-		"rejects %s",
-		(input) => {
-			expect(isPagoMovilQr(input)).toBe(false);
-		},
-	);
+	it.each([
+		["empty", ""],
+		["no query", "SGVsbG8="],
+		["short blob", "SGVsbG8=?merchantId=0134"],
+		["missing merchantId", `${"A".repeat(48)}?bank=BANCO_A`],
+		["non-base64", "not base64!@#?merchantId=0134"],
+		["empty blob", "?merchantId=0134"],
+	])("rejects %s", (_label, input) => {
+		expect(isPagoMovilQr(input)).toBe(false);
+	});
 });
 
 describe("parsePagoMovil (VEN)", () => {
-	it("returns the full QR string as payment address for base64 payload + query", () => {
-		const qr = "SGVsbG9Xb3JsZA==?param=1";
-		const data = unwrap(parsePagoMovil(qr, 40));
-		expect(data.paymentAddress).toBe(qr);
+	it("returns the full Tesoro QR string as payment address", () => {
+		const data = unwrap(parsePagoMovil(TESORO, 40));
+		expect(data.paymentAddress).toBe(TESORO);
 	});
 
 	it("trims whitespace but preserves the trimmed QR as payment address", () => {
-		const qr = "dGVzdA==?x=y";
-		const data = unwrap(parsePagoMovil(`  ${qr}  `, 40));
-		expect(data.paymentAddress).toBe(qr);
+		const data = unwrap(parsePagoMovil(`  ${MERCANTIL}  `, 40));
+		expect(data.paymentAddress).toBe(MERCANTIL);
 	});
 
 	it.each([
@@ -58,48 +56,26 @@ describe("parsePagoMovil (VEN)", () => {
 	});
 
 	it("returns INVALID_QR when payload has non-base64 characters", () => {
-		const result = parsePagoMovil("not base64!@#?x=y", 40);
+		const result = parsePagoMovil("not base64!@#?merchantId=0134", 40);
 		expect(result.isErr()).toBe(true);
 		if (result.isErr()) expect(result.error.code).toBe("INVALID_QR");
 	});
 
 	it("returns INVALID_QR when payload before '?' is empty", () => {
-		const result = parsePagoMovil("?x=y", 40);
+		const result = parsePagoMovil("?merchantId=0134", 40);
 		expect(result.isErr()).toBe(true);
 		if (result.isErr()) expect(result.error.code).toBe("INVALID_QR");
 	});
-});
 
-describe("parsePagoMovil (VEN) — real-world examples", () => {
-	// Venezuelan PagoMóvil QRs are an opaque base64-encoded payload that only
-	// the banks can decipher, followed by a `?` and routing metadata.
-	// The base64 below decodes to:
-	//   "the venezuelan qr is a base64 encrypted string that only banks can decipher"
-	const VEN_BASE64 =
-		"dGhlIHZlbmV6dWVsYW4gcXIgaXMgYSBiYXNlNjQgZW5jcnlwdGVkIHN0cmluZyB0aGF0IG9ubHkgYmFua3MgY2FuIGRlY2lwaGVy";
-
-	const VEN_BANCO_A = `${VEN_BASE64}?bank=BANCO_A`;
-	const VEN_BANCO_B = `${VEN_BASE64}?bank=BANCO_B`;
-	const VEN_BANCO_C = `${VEN_BASE64}?bank=BANCO_C`;
-	const VEN_BANCO_D = `${VEN_BASE64}?bank=BANCO_D`;
-
-	it("parses a PagoMóvil QR routed to BANCO_A", () => {
-		const data = unwrap(parsePagoMovil(VEN_BANCO_A, 40));
-		expect(data.paymentAddress).toBe(VEN_BANCO_A);
+	it("returns INVALID_QR when merchantId is missing (same rule as SELL upload)", () => {
+		const result = parsePagoMovil(`${"A".repeat(48)}?bank=BANCO_A`, 40);
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) expect(result.error.code).toBe("INVALID_QR");
 	});
 
-	it("parses a PagoMóvil QR routed to BANCO_B", () => {
-		const data = unwrap(parsePagoMovil(VEN_BANCO_B, 40));
-		expect(data.paymentAddress).toBe(VEN_BANCO_B);
-	});
-
-	it("parses a PagoMóvil QR routed to BANCO_C", () => {
-		const data = unwrap(parsePagoMovil(VEN_BANCO_C, 40));
-		expect(data.paymentAddress).toBe(VEN_BANCO_C);
-	});
-
-	it("parses a PagoMóvil QR routed to BANCO_D", () => {
-		const data = unwrap(parsePagoMovil(VEN_BANCO_D, 40));
-		expect(data.paymentAddress).toBe(VEN_BANCO_D);
+	it("returns INVALID_QR when the blob is shorter than 40 characters", () => {
+		const result = parsePagoMovil("SGVsbG8=?merchantId=0134", 40);
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) expect(result.error.code).toBe("INVALID_QR");
 	});
 });


### PR DESCRIPTION
## Summary

Two catalog additions. Apps must not branch on `PEN` / `VEN` / `PHP` / `CUP` for these.

### Scan & Pay QR display
- Optional `CountryOption.getPayQrPayload` plus dispatcher `getPayQrPayload(currency, id)` (strict `getStoredQrPayload` first, then the hook).
- PAY display may be looser than SELL upload: PEN Yape/Plin without CRC, VEN Pago Móvil envelope without `merchantId`, PHP QR Ph vs InstaPay `phone|bank`.
- `assignStoredPaymentIdToFieldValues` no longer dumps a standalone PAY blob into typed fields (PHP).
- Scan & Pay parsers align with SELL: `parsePeru` requires CRC; `parsePagoMovil` / `isPagoMovilQr` require the S7B envelope. `parseQR` re-checks `validateQr` when the country has one.
- Changeset: `.changeset/pay-qr-payload.md` (minor). Version stays `1.2.17` until publish.

### CUP BANDEC
- Optional `CountryOption.transferWarning` (i18n key) plus `getTransferWarning(currency)`.
- CUP sets `CUP_BANDEC_WARNING`. Translations live in the apps.
- Changeset: `.changeset/cup-transfer-warning.md` (minor).

## Test plan
- [ ] `bun test test/country/pay-qr-payload.test.ts test/country/transfer-warning.test.ts test/qr-parsers/`
- [ ] PEN: SELL still requires CRC; PAY redraws `0002`+PE+604 without CRC
- [ ] VEN: SELL still requires `merchantId`; PAY redraws `base64?…`
- [ ] PHP: QR Ph is a PAY QR; `phone|bank` is not
- [ ] `getTransferWarning('CUP')` is `CUP_BANDEC_WARNING`; other currencies are `undefined`
- [ ] Publish this SDK before merging the user-app / merchant PRs


Made with [Cursor](https://cursor.com)