### PR TITLE
feat(country): INR getPayQrPayload for UPI Scan & Pay

### DIFF
--- a/.changeset/inr-pay-qr-payload.md
+++ b/.changeset/inr-pay-qr-payload.md
@@ -1,0 +1,8 @@
+---
+"@p2pdotme/sdk": patch
+---
+
+country: INR `getPayQrPayload` for UPI Scan & Pay intents
+
+- `isIndianPayQr` treats `upi://pay?pa=…` as a PAY QR. A bare VPA (`user@bank`) stays a typed field (SELL).
+- `hydrateFieldsFromQr` fills `upi` from `pa=` so receipts show the VPA, not the URI blob.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p2pdotme/sdk",
-  "version": "1.2.20",
+  "version": "1.2.21",
   "description": "P2P.me SDK",
   "license": "MIT",
   "type": "module",

--- a/src/country/README.md
+++ b/src/country/README.md
@@ -119,7 +119,7 @@ getStoredQrPayload("PEN", storedId); // EMVCo blob or null
 getPayQrPayload("PEN", scannedBlob); // same, even if CRC fails
 getPayQrPayload("BOB", scannedBlob); // QR Simple EMVCo or encrypted envelope
 getPayQrPayload("PHP", qrPhBlob); // QR Ph EMVCo; null for phone|bank
-getPayQrPayload("INR", "upi://pay?pa=m@b&cu=INR"); // UPI intent; null for m@b
+getPayQrPayload("INR", "upi://pay?pa=user@bank"); // UPI intent; null for `user@bank`
 ```
 
 ## Validators

--- a/src/country/README.md
+++ b/src/country/README.md
@@ -87,7 +87,7 @@ Scan & pay (PAY) is a different path: `parseQR` stores the scanned blob as the p
 
 `validateQr` — this currency may store a QR in the payment ID (`qr||fields` or standalone). `usesPackedPaymentId(currency)` is true when `validateQr` exists.
 
-`getPayQrPayload` — optional CountryOption hook for PAY **display**. Scan & Pay uses the same `validateQr` as SELL (`parsePeru` CRC, `parsePagoMovil` `merchantId`, `validateBolivianQr` envelope/CRC). The hook may still re-draw a blob already stored (PEN without CRC, VEN without `merchantId`, BOB EMVCo without CRC or a non-24/32 hex envelope, PHP QR Ph vs InstaPay `phone|bank`). Apps must not branch on currency.
+`getPayQrPayload` — optional CountryOption hook for PAY **display**. Scan & Pay uses the same `validateQr` as SELL (`parsePeru` CRC, `parsePagoMovil` `merchantId`, `validateBolivianQr` envelope/CRC). The hook may still re-draw a blob already stored (PEN without CRC, VEN without `merchantId`, BOB EMVCo without CRC or a non-24/32 hex envelope, PHP QR Ph vs InstaPay `phone|bank`, INR `upi://pay?…` vs a typed VPA). Apps must not branch on currency.
 
 `optional: true` — empty value allowed for that field. If every field is optional, at least one must still be filled (`validatePaymentIdFields`). Packed QR + fields are validated with `validateStoredPaymentId`. QR and typed fields may coexist; if any typed field has text, non-optional catalog fields are all required. Forms call `validateCatalogPaymentDraft(currency, qr, fieldValues)` and show `field.validationErrorMessage` on invalid fields. Layout copy (one generic “if they cannot scan, fill the details” hint) stays in the apps — not a per-country catalog hook.
 
@@ -119,6 +119,7 @@ getStoredQrPayload("PEN", storedId); // EMVCo blob or null
 getPayQrPayload("PEN", scannedBlob); // same, even if CRC fails
 getPayQrPayload("BOB", scannedBlob); // QR Simple EMVCo or encrypted envelope
 getPayQrPayload("PHP", qrPhBlob); // QR Ph EMVCo; null for phone|bank
+getPayQrPayload("INR", "upi://pay?pa=m@b&cu=INR"); // UPI intent; null for m@b
 ```
 
 ## Validators

--- a/src/country/currencies/inr.ts
+++ b/src/country/currencies/inr.ts
@@ -1,4 +1,5 @@
 import { CURRENCY } from "../currency";
+import { isIndianPayQr, payQrCandidate } from "../qr-validator";
 import type { CountryOption, PaymentIdFieldConfig } from "../types";
 
 export const INR_PLACEHOLDER = "merchant@upi";
@@ -46,4 +47,18 @@ export const INR_COUNTRY_OPTION: CountryOption = {
 	isAlpha: false,
 	disabled: false,
 	disabledPaymentTypes: [],
+	getPayQrPayload: (paymentId) => {
+		const candidate = payQrCandidate(paymentId);
+		return isIndianPayQr(candidate) ? candidate : null;
+	},
+	hydrateFieldsFromQr: (qr) => {
+		let paramString = qr.trim();
+		if (paramString.startsWith("upi://pay?")) {
+			paramString = paramString.slice(10);
+		} else if (paramString.includes("?")) {
+			paramString = paramString.split("?")[1] ?? "";
+		}
+		const pa = new URLSearchParams(paramString).get("pa")?.trim() ?? "";
+		return pa && validateUPIId(pa) ? { upi: pa } : {};
+	},
 };

--- a/src/country/currencies/inr.ts
+++ b/src/country/currencies/inr.ts
@@ -27,7 +27,12 @@ export const INR_PAYMENT_FIELDS: PaymentIdFieldConfig[] = [
 	},
 ];
 
-/** Country option for India (INR). */
+/**
+ * Country option for India (INR).
+ *
+ * SELL is a typed VPA (`user@bank`). Scan & Pay stores the full UPI intent
+ * (`upi://pay?pa=user@bank&…`) as the payment ID.
+ */
 export const INR_COUNTRY_OPTION: CountryOption = {
 	country: "India",
 	currency: CURRENCY.INR,
@@ -47,10 +52,19 @@ export const INR_COUNTRY_OPTION: CountryOption = {
 	isAlpha: false,
 	disabled: false,
 	disabledPaymentTypes: [],
+	/**
+	 * PAY display: re-draw a Scan & Pay UPI intent as a QR.
+	 * `upi://pay?pa=merchant@upi&cu=INR&…` → that same string (scannable).
+	 * `merchant@upi` alone is a typed SELL VPA → null (show as text).
+	 */
 	getPayQrPayload: (paymentId) => {
 		const candidate = payQrCandidate(paymentId);
 		return isIndianPayQr(candidate) ? candidate : null;
 	},
+	/**
+	 * Read `pa=` from the intent so the receipt label is the VPA
+	 * (`merchant@upi`), not the raw `upi://pay?…` blob.
+	 */
 	hydrateFieldsFromQr: (qr) => {
 		let paramString = qr.trim();
 		if (paramString.startsWith("upi://pay?")) {

--- a/src/country/qr-validator.ts
+++ b/src/country/qr-validator.ts
@@ -174,3 +174,26 @@ export function isBolivianPayQr(payload: string): boolean {
 	if (!/^[A-Za-z0-9+/]+={0,2}$/.test(blob)) return false;
 	return /^[0-9A-Fa-f]{16,64}$/.test(tag);
 }
+
+/**
+ * PAY display: UPI intent (`upi://pay?pa=…`). A bare VPA (`user@bank`) is not a
+ * QR — SELL India stores that as a typed field. Scan & Pay persists the scanned
+ * URI; CRC/signature (`sign`/`sing`) is not required to re-draw.
+ */
+export function isIndianPayQr(payload: string): boolean {
+	if (!payload || payload.includes(PACKED_PAYMENT_ID_SEP)) return false;
+	const trimmed = payload.trim();
+	if (/^[a-zA-Z0-9.\-_]{2,256}@[a-zA-Z0-9]{2,64}$/.test(trimmed)) return false;
+
+	let paramString: string;
+	if (trimmed.startsWith("upi://pay?")) {
+		paramString = trimmed.slice(10);
+	} else if (trimmed.includes("?")) {
+		paramString = trimmed.split("?")[1] ?? "";
+	} else {
+		return false;
+	}
+
+	const pa = new URLSearchParams(paramString).get("pa");
+	return !!pa && /^[a-zA-Z0-9.\-_]{2,256}@[a-zA-Z0-9]{2,64}$/.test(pa.trim());
+}

--- a/src/country/validators.ts
+++ b/src/country/validators.ts
@@ -30,6 +30,7 @@ export {
 } from "./currencies";
 export {
 	isBolivianPayQr,
+	isIndianPayQr,
 	isPeruvianPayQr,
 	isPhilippinePayQr,
 	isVenezuelanPayQr,

--- a/test/country/pay-qr-payload-unwired.test.ts
+++ b/test/country/pay-qr-payload-unwired.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+	formatStoredPaymentIdForDisplay,
+	getPayQrPayload,
+	getStoredQrPayload,
+} from "../../src/country";
+
+/**
+ * Scan & Pay countries whose `CountryOption` still has no `getPayQrPayload`.
+ * Parsers already exist (`test/qr-parsers/*`); the receipt/drawer catalog hook
+ * does not.
+ *
+ * Assertions here document the gap (`null` / blob dumped as text). When a hook
+ * lands, flip: `getPayQrPayload(currency, blob)` → `blob`, and
+ * `formatStoredPaymentIdForDisplay` must not equal the blob. SELL short-ID
+ * tests in the first describe must stay `null`.
+ */
+
+const ARS_QR =
+	"00020101021126410016com.mercadolibre0109111111111020400005204000053030325802AR5911PERSONA UNO6008CIUDAD B630467A9";
+const BRL_PIX =
+	"00020126340014BR.GOV.BCB.PIX0112foo@bar.test5204000053039865406150.005802BR5914NOME RECEBEDOR6008CIDADE A62100506PED00163045F53";
+const IDR_QRIS =
+	"00020101021126430017ID.CO.EXAMPLE.WWW01189360098800009876545204541153033605802ID5915TOKO CONTOH DUA600905 KOTA B";
+const NGN_SPD = "SPD*1.0*ACC:1234567890*AM:40,000.00*MSG:Test*";
+const COP_EMV = "0002010102115204000053031705802CO5913TEST MERCHANT6304ABCD";
+const CUP_TM = "TRANSFERMOVIL_ETECSA,TRANSFERENCIA,9204959800000000,58555555,";
+const ECU_DEUNA = "https://pagar.deuna.app/demo/merchant?id=demomerchant123";
+
+describe("SELL short IDs must never become a PAY QR", () => {
+	it.each([
+		["ARS", "juan.perez"],
+		["BRL", "foo@bar.test"],
+		["IDR", "8123456789"],
+		["NGN", "1234567890"],
+		["COP", "3001234567"],
+		["CUP", "58555555|9204959800000000"],
+		["MEX", "012345678901234567"],
+	] as const)("%s typed / compound id is not a QR", (currency, id) => {
+		expect(getPayQrPayload(currency, id)).toBeNull();
+		expect(getStoredQrPayload(currency, id)).toBeNull();
+	});
+});
+
+describe("typed-only currencies have no PAY QR hook", () => {
+	it("MEX / EUR / USD stay null", () => {
+		expect(getPayQrPayload("MEX", "012345678901234567")).toBeNull();
+		expect(getPayQrPayload("EUR", "@alice")).toBeNull();
+		expect(getPayQrPayload("USD", "@alice")).toBeNull();
+	});
+});
+
+describe("unwired PAY blobs (getPayQrPayload is still null)", () => {
+	it.each([
+		["ARS", ARS_QR],
+		["BRL", BRL_PIX],
+		["IDR", IDR_QRIS],
+		["NGN", NGN_SPD],
+		["COP", COP_EMV],
+		["CUP", CUP_TM],
+		["ECU", ECU_DEUNA],
+	] as const)("%s scanned blob is not a catalog PAY QR yet", (currency, blob) => {
+		expect(getPayQrPayload(currency, blob)).toBeNull();
+		expect(getStoredQrPayload(currency, blob)).toBeNull();
+	});
+
+	it("ARS / BRL / IDR one-field catalogs dump the PAY blob as display text", () => {
+		expect(formatStoredPaymentIdForDisplay("ARS", ARS_QR)).toBe(ARS_QR);
+		expect(formatStoredPaymentIdForDisplay("BRL", BRL_PIX)).toBe(BRL_PIX);
+		expect(formatStoredPaymentIdForDisplay("IDR", IDR_QRIS)).toBe(IDR_QRIS);
+	});
+});

--- a/test/country/pay-qr-payload.test.ts
+++ b/test/country/pay-qr-payload.test.ts
@@ -77,4 +77,31 @@ describe("getPayQrPayload", () => {
 			"bank-name": "GCash",
 		});
 	});
+
+	it("returns an INR UPI intent and ignores a bare VPA", () => {
+		const intent =
+			"upi://pay?pa=chandoo@nsdl&pn=Merchant&cu=INR&mode=02&purpose=00&orgid=159772&sing=abc";
+		expect(getStoredQrPayload("INR", intent)).toBeNull();
+		expect(getPayQrPayload("INR", intent)).toBe(intent);
+		expect(getPayQrPayload("INR", "chandoo@nsdl")).toBeNull();
+	});
+
+	it("does not dump an INR PAY intent into the UPI field", () => {
+		const intent = "upi://pay?pa=chandoo@nsdl&cu=INR&mode=02";
+		expect(assignStoredPaymentIdToFieldValues("INR", intent)).toEqual({
+			upi: "chandoo@nsdl",
+		});
+		expect(formatStoredPaymentIdForDisplay("INR", intent)).toBe("chandoo@nsdl");
+		expect(assignStoredPaymentIdToFieldValues("INR", "merchant@ybl")).toEqual({
+			upi: "merchant@ybl",
+		});
+	});
+
+	it("redraws a signed INR static QR without am= (production BharatQR shape)", () => {
+		const intent =
+			"upi://pay?pa=chandoo@nsdl&pn=Merchant%20Name&cu=INR&mode=02&purpose=00&orgid=159772&sing=WM7QoTvWzabc";
+		expect(getPayQrPayload("INR", intent)).toBe(intent);
+		expect(formatStoredPaymentIdForDisplay("INR", intent)).toBe("chandoo@nsdl");
+		expect(formatStoredPaymentIdForDisplay("INR", intent)).not.toBe(intent);
+	});
 });


### PR DESCRIPTION
## Summary
- Add `isIndianPayQr` / `getPayQrPayload` so Scan & Pay `upi://pay?pa=…` redraws as a QR; a typed SELL VPA stays `user@bank`.
- `hydrateFieldsFromQr` fills the UPI field from `pa=` so receipts show the VPA, not the URI blob.
- Patch changeset; version **1.2.21**.

## Test plan
- [ ] `bun test test/country/pay-qr-payload.test.ts test/country/pay-qr-payload-unwired.test.ts`
- [ ] `getPayQrPayload("INR", "upi://pay?pa=chandoo@nsdl&cu=INR")` returns the intent; `"chandoo@nsdl"` returns null
- [ ] `formatStoredPaymentIdForDisplay` for a signed BharatQR intent is the VPA, not the full URI


Made with [Cursor](https://cursor.com)